### PR TITLE
Python3 update

### DIFF
--- a/src/RestrictedPython/Guards.py
+++ b/src/RestrictedPython/Guards.py
@@ -266,3 +266,15 @@ safe_builtins['setattr'] = guarded_setattr
 def guarded_delattr(object, name):
     delattr(full_write_guard(object), name)
 safe_builtins['delattr'] = guarded_delattr
+
+
+def guarded_unpack_sequence(it, spec, _getiter_):
+    ret = list(_getiter_(it))
+
+    if len(ret) < spec['min_len']:
+        return ret
+
+    for (idx, child_spec) in spec['childs']:
+        ret[idx] = guarded_unpack_sequence(ret[idx], child_spec, _getiter_)
+
+    return ret

--- a/src/RestrictedPython/Guards.py
+++ b/src/RestrictedPython/Guards.py
@@ -268,6 +268,11 @@ def guarded_delattr(object, name):
 safe_builtins['delattr'] = guarded_delattr
 
 
+def guarded_iter_unpack_sequence(it, spec, _getiter_):
+    for ob in _getiter_(it):
+        yield guarded_unpack_sequence(ob, spec, _getiter_)
+
+
 def guarded_unpack_sequence(it, spec, _getiter_):
     ret = list(_getiter_(it))
 

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -197,8 +197,6 @@ def copy_locations(new_node, old_node):
     ast.fix_missing_locations(new_node)
 
 
-
-
 class RestrictingNodeTransformer(ast.NodeTransformer):
 
     def __init__(self, errors=[], warnings=[], used_names=[]):
@@ -214,7 +212,7 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         # 'check_name' ensures that no variable is prefixed with '_'.
         # => Its safe to use '_tmp..' as a temporary variable.
         name = '_tmp%i' % self._tmp_idx
-        self._tmp_idx +=1
+        self._tmp_idx += 1
         return name
 
     def error(self, node, info):
@@ -1328,7 +1326,7 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         return self.generic_visit(node)
 
     def visit_ClassDef(self, node):
-        """Checks the name of classes."""
+        """Check the name of a class definition."""
 
         self.check_name(node, node.name)
         return self.generic_visit(node)

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -1466,9 +1466,9 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         return self.generic_visit(node)
 
     def visit_ClassDef(self, node):
-        """
+        """Checks the name of classes."""
 
-        """
+        self.check_name(node, node.name)
         return self.generic_visit(node)
 
     def visit_Module(self, node):

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -1187,15 +1187,21 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
     # Imports
 
     def visit_Import(self, node):
-        """
+        """ """
+        for alias in node.names:
+            self.check_name(node, alias.name)
+            if alias.asname:
+                self.check_name(node, alias.asname)
 
-        """
         return self.generic_visit(node)
 
     def visit_ImportFrom(self, node):
-        """
+        """ """
+        for alias in node.names:
+            self.check_name(node, alias.name)
+            if alias.asname:
+                self.check_name(node, alias.asname)
 
-        """
         return self.generic_visit(node)
 
     def visit_alias(self, node):

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -247,10 +247,17 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         """
         node = self.generic_visit(node)
 
-        new_iter = ast.Call(
-            func=ast.Name("_getiter_", ast.Load()),
-            args=[node.iter],
-            keywords=[])
+        if isinstance(node.target, ast.Tuple):
+            spec = self.gen_unpack_spec(node.target)
+            new_iter = ast.Call(
+                func=ast.Name('_iter_unpack_sequence_', ast.Load()),
+                args=[node.iter, spec, ast.Name('_getiter_', ast.Load())],
+                keywords=[])
+        else:
+            new_iter = ast.Call(
+                func=ast.Name("_getiter_", ast.Load()),
+                args=[node.iter],
+                keywords=[])
 
         copy_locations(new_iter, node.iter)
         node.iter = new_iter

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -388,7 +388,7 @@ def test_transformer__RestrictingNodeTransformer__visit_Subscript_2(compile, moc
 
 
 @pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_AugAssing(compile, mocker):
+def test_transformer__RestrictingNodeTransformer__visit_AugAssign(compile, mocker):
     _inplacevar_ = mocker.stub()
     _inplacevar_.side_effect = lambda op, val, expr: val + expr
 
@@ -621,7 +621,7 @@ def test_transformer__RestrictingNodeTransformer__visit_Lambda_2(compile, mocker
 
 @pytest.mark.parametrize(*compile)
 def test_transformer__RestrictingNodeTransformer__visit_Assign(compile, mocker):
-    src = "(a, (x, z)) = (c, d) = g"
+    src = "orig = (a, (x, z)) = (c, d) = g"
     code, errors = compile(src)[:2]
 
     _getiter_ = mocker.stub()
@@ -639,6 +639,7 @@ def test_transformer__RestrictingNodeTransformer__visit_Assign(compile, mocker):
     assert glb['z'] == 3
     assert glb['c'] == 1
     assert glb['d'] == (2, 3)
+    assert glb['orig'] == (1, (2, 3))
     assert _getiter_.call_count == 3
     _getiter_.assert_any_call((1, (2, 3)))
     _getiter_.assert_any_call((2, 3))

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,5 +1,5 @@
-from RestrictedPython.Guards import guarded_unpack_sequence
 from RestrictedPython.Guards import guarded_iter_unpack_sequence
+from RestrictedPython.Guards import guarded_unpack_sequence
 
 import pytest
 import RestrictedPython

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -922,6 +922,7 @@ def test_transformer__RestrictingNodeTransformer__visit_ClassDef(compile):
     assert code is not None
     assert errors == ()
 
+    # Do not allow class names which start with an underscore.
     code, errors = compile('class _bad: pass')[:2]
     assert code is None
     assert errors[0] == 'Line 1: "_bad" is an invalid variable name ' \

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -195,6 +195,22 @@ def no_exec():
 """
 
 
+DISALLOW_TRACEBACK_ACCESS = """
+try:
+    raise Exception()
+except Exception as e:
+    tb = e.__traceback__
+"""
+
+
+@pytest.mark.parametrize(*compile)
+def test_transformer__RestrictingNodeTransformer__visit_Attribute__6(compile):
+    code, errors = compile(DISALLOW_TRACEBACK_ACCESS)[:2]
+    assert code is None
+    assert errors[0] == 'Line 5: "__traceback__" is an invalid attribute ' \
+                        'name because it starts with "_".'
+
+
 @pytest.mark.skipif(sys.version_info < (3, 0),
                     reason="exec is a statement in Python 2")
 @pytest.mark.parametrize(*compile)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -782,3 +782,44 @@ def test_transformer__RestrictingNodeTransformer__visit_ExceptHandler(compile, m
     _getiter_.assert_has_calls([
         mocker.call(err),
         mocker.call((2, 3))])
+
+
+@pytest.mark.parametrize(*compile)
+def test_transformer__RestrictingNodeTransformer__visit_Import(compile):
+    def do_compile(src):
+        return compile.compile_restricted_exec(src)[:2]
+
+    errmsg = 'Line 1: "%s" is an invalid variable name ' \
+             'because it starts with "_"'
+
+    code, errors = do_compile('import a')
+    assert code != None
+    assert errors == ()
+
+    code, errors = do_compile('import _a')
+    assert code == None
+    assert errors[0] == (errmsg % '_a')
+
+    code, errors = do_compile('import _a as m')
+    assert code == None
+    assert errors[0] == (errmsg % '_a')
+
+    code, errors = do_compile('import a as _m')
+    assert code == None
+    assert errors[0] == (errmsg % '_m')
+
+    code, errors = do_compile('from a import m')
+    assert code != None
+    assert errors == ()
+
+    code, errors = do_compile('from _a import m')
+    assert code != None
+    assert errors == ()
+
+    code, errors = do_compile('from a import m as _n')
+    assert code == None
+    assert errors[0] == (errmsg % '_n')
+
+    code, errors = do_compile('from a import _m as n')
+    assert code == None
+    assert errors[0] == (errmsg % '_m')

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,3 +1,5 @@
+from RestrictedPython.Guards import guarded_unpack_sequence
+
 import pytest
 import RestrictedPython
 import six
@@ -514,7 +516,12 @@ def test_transformer__RestrictingNodeTransformer__visit_FunctionDef_2(compile, m
 
     _getiter_ = mocker.stub()
     _getiter_.side_effect = lambda it: it
-    glb = {'_getiter_': _getiter_}
+
+    glb = {
+        '_getiter_': _getiter_,
+        '_unpack_sequence_': guarded_unpack_sequence
+    }
+
     six.exec_(code, glb)
 
     val = (1, 2)
@@ -597,6 +604,7 @@ def test_transformer__RestrictingNodeTransformer__visit_Lambda_2(compile, mocker
     _getiter_.side_effect = lambda it: it
     glb = {
         '_getiter_': _getiter_,
+        '_unpack_sequence_': guarded_unpack_sequence,
         '_getattr_': lambda ob, val: getattr(ob, val)
     }
 
@@ -618,7 +626,12 @@ def test_transformer__RestrictingNodeTransformer__visit_Assign(compile, mocker):
 
     _getiter_ = mocker.stub()
     _getiter_.side_effect = lambda it: it
-    glb = {'g': (1, (2, 3)), '_getiter_': _getiter_}
+
+    glb = {
+        '_getiter_': _getiter_,
+        '_unpack_sequence_': guarded_unpack_sequence,
+        'g': (1, (2, 3)),
+    }
 
     six.exec_(code, glb)
     assert glb['a'] == 1
@@ -744,7 +757,11 @@ def test_transformer__RestrictingNodeTransformer__visit_ExceptHandler(compile, m
     _getiter_ = mocker.stub()
     _getiter_.side_effect = lambda it: it
 
-    glb = {'_getiter_': _getiter_}
+    glb = {
+        '_getiter_': _getiter_,
+        '_unpack_sequence_': guarded_unpack_sequence
+    }
+
     six.exec_(code, glb)
 
     err = Exception(1, (2, 3))

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -792,3 +792,15 @@ def test_transformer__RestrictingNodeTransformer__visit_Import(compile):
     code, errors = compile('from a import _m as n')[:2]
     assert code == None
     assert errors[0] == (errmsg % '_m')
+
+
+@pytest.mark.parametrize(*compile)
+def test_transformer__RestrictingNodeTransformer__visit_ClassDef(compile):
+    code, errors = compile('class Good: pass')[:2]
+    assert code is not None
+    assert errors == ()
+
+    code, errors = compile('class _bad: pass')[:2]
+    assert code is None
+    assert errors[0] == 'Line 1: "_bad" is an invalid variable name ' \
+                        'because it starts with "_"'

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -340,7 +340,6 @@ def test_transformer__RestrictingNodeTransformer__guard_iter2(compile, mocker):
     _getiter_.assert_has_calls(call_ref)
     _getiter_.reset_mock()
 
-
     ret = glb['set_comp'](it)
     assert ret == {3, 7, 11}
     _getiter_.assert_has_calls(call_ref)
@@ -573,7 +572,7 @@ def test_transformer__RestrictingNodeTransformer__visit_FunctionDef_1(compile):
         assert errors[0] == err_msg
 
 
-NESTED_SEQ_UNPACK =  """
+NESTED_SEQ_UNPACK = """
 def nested((a, b, (c, (d, e)))):
     return a, b, c, d, e
 
@@ -794,10 +793,11 @@ def try_except_else_finally(m):
         m('finally')
 """
 
+
 @pytest.mark.parametrize(*compile)
 def test_transformer__RestrictingNodeTransformer__error_handling(compile, mocker):
     code, errors = compile(TRY_EXCEPT_FINALLY)[:2]
-    assert code != None
+    assert code is not None
 
     glb = {}
     six.exec_(code, glb)
@@ -857,7 +857,7 @@ def tuple_unpack(err):
 @pytest.mark.parametrize(*compile)
 def test_transformer__RestrictingNodeTransformer__visit_ExceptHandler(compile, mocker):
     code, errors = compile(EXCEPT_WITH_TUPLE_UNPACK)[:2]
-    assert code != None
+    assert code is not None
 
     _getiter_ = mocker.stub()
     _getiter_.side_effect = lambda it: it
@@ -884,35 +884,35 @@ def test_transformer__RestrictingNodeTransformer__visit_Import(compile):
              'because it starts with "_"'
 
     code, errors = compile('import a')[:2]
-    assert code != None
+    assert code is not None
     assert errors == ()
 
     code, errors = compile('import _a')[:2]
-    assert code == None
+    assert code is None
     assert errors[0] == (errmsg % '_a')
 
     code, errors = compile('import _a as m')[:2]
-    assert code == None
+    assert code is None
     assert errors[0] == (errmsg % '_a')
 
     code, errors = compile('import a as _m')[:2]
-    assert code == None
+    assert code is None
     assert errors[0] == (errmsg % '_m')
 
     code, errors = compile('from a import m')[:2]
-    assert code != None
+    assert code is not None
     assert errors == ()
 
     code, errors = compile('from _a import m')[:2]
-    assert code != None
+    assert code is not None
     assert errors == ()
 
     code, errors = compile('from a import m as _n')[:2]
-    assert code == None
+    assert code is None
     assert errors[0] == (errmsg % '_n')
 
     code, errors = compile('from a import _m as n')[:2]
-    assert code == None
+    assert code is None
     assert errors[0] == (errmsg % '_m')
 
 


### PR DESCRIPTION
Hey,

I found a more elegant way to guard 'unpack sequence' without modifying the bytecode.
By introducing two new functions to the globals, the transformer creates only a specification how the sequence unpacking should happen.
Then he converts the unpacking like this
```
(a, b, (c, d)) = g
# becomes
(a, b, (c, d)) = _unpack_sequence_(g, <spec>, _getiter_)
```
The spec tells unpack sequence to
* call `_getiter_` on the g
* call `_getiter_` on the third element on the result of `_getiter_(g)`

This makes it possible to protect tuple unpacking in all kinds of for loops.

I also added
* checks for class names.
* checks for import names 
* unittest for sequence unpacking with starred elements