### PR TITLE
Use released pytest-mock

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     pytest-remove-stale-bytecode
     pytest-flake8
     pytest-isort
-    git+https://github.com/pytest-dev/pytest-mock@931785ca86113c62baaad1e677f5dc61d69ec39a
+    pytest-mock
 #    pytest-mypy
 
 [testenv:coverage-clean]


### PR DESCRIPTION
There is now a released version of pytest-mock which supports Python 3.6.