### PR TITLE
Add built-in function 'set'

### DIFF
--- a/src/RestrictedPython/Guards.py
+++ b/src/RestrictedPython/Guards.py
@@ -23,7 +23,7 @@ safe_builtins = {}
 for name in ['False', 'None', 'True', 'abs', 'basestring', 'bool', 'callable',
              'chr', 'cmp', 'complex', 'divmod', 'float', 'hash',
              'hex', 'id', 'int', 'isinstance', 'issubclass', 'len',
-             'long', 'oct', 'ord', 'pow', 'range', 'repr', 'round',
+             'long', 'oct', 'ord', 'pow', 'range', 'repr', 'round', 'set',
              'str', 'tuple', 'unichr', 'unicode', 'xrange', 'zip']:
 
     safe_builtins[name] = __builtins__[name]

--- a/src/RestrictedPython/tests/restricted_module.py
+++ b/src/RestrictedPython/tests/restricted_module.py
@@ -33,6 +33,11 @@ def try_map():
     print map(inc, x),
     return printed
 
+def try_set():
+    x = [1, 1, 2, 3]
+    print set(x)
+    return printed
+
 def try_apply():
     def f(x, y, z):
         return x + y + z

--- a/src/RestrictedPython/tests/testRestrictions.py
+++ b/src/RestrictedPython/tests/testRestrictions.py
@@ -251,6 +251,10 @@ class RestrictionTests(unittest.TestCase):
         res = self.execFunc('try_map')
         self.assertEqual(res, "[2, 3, 4]")
 
+    def checkTrySet(self):
+        res = self.execFunc('try_set')
+        self.assertEqual(res, "set([1, 2, 3])")
+
     def checkApply(self):
         del apply_wrapper_called[:]
         res = self.execFunc('try_apply')


### PR DESCRIPTION
Adding built-in function 'set' to `safe_builtins`. Sets can be created with the {x, y} notation, but there's no way to create an empty set.