### PR TITLE
Clean up pytest marks

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,15 +11,15 @@ def _compile(compile_func, source):
     return result.code
 
 
-def _execute(compile_func):
+def _exec(compile_func):
     """Factory to create an execute function."""
-    def _execute(source, glb=None):
+    def _exec(source, glb=None):
         code = _compile(compile_func, source)
         if glb is None:
             glb = {}
         exec(code, glb)
         return glb
-    return _execute
+    return _exec
 
 
 def _eval(compile_func):
@@ -34,17 +34,18 @@ def _eval(compile_func):
 
 # Define the arguments for @pytest.mark.parametrize to be able to test both the
 # old and the new implementation to be equal:
-compile = ('compile', [RestrictedPython.compile.compile_restricted_exec])
-compile_eval = ('compile_eval',
-                [RestrictedPython.compile.compile_restricted_eval])
-execute = ('execute',
-           [_execute(RestrictedPython.compile.compile_restricted_exec)])
-r_eval = ('r_eval',
-          [_eval(RestrictedPython.compile.compile_restricted_eval)])
+# Compile in `exec` mode.
+c_exec = ('c_exec', [RestrictedPython.compile.compile_restricted_exec])
+# Compile and execute in `exec` mode.
+e_exec = ('e_exec', [_exec(RestrictedPython.compile.compile_restricted_exec)])
+# Compile in `eval` mode.
+c_eval = ('c_eval', [RestrictedPython.compile.compile_restricted_eval])
+# Compile and execute in `eval` mode.
+e_eval = ('e_eval', [_eval(RestrictedPython.compile.compile_restricted_eval)])
 
 if IS_PY2:
     from RestrictedPython import RCompile
-    compile[1].append(RCompile.compile_restricted_exec)
-    compile_eval[1].append(RCompile.compile_restricted_eval)
-    execute[1].append(_execute(RCompile.compile_restricted_exec))
-    r_eval[1].append(_eval(RCompile.compile_restricted_eval))
+    c_exec[1].append(RCompile.compile_restricted_exec)
+    c_eval[1].append(RCompile.compile_restricted_eval)
+    e_exec[1].append(_exec(RCompile.compile_restricted_exec))
+    e_eval[1].append(_eval(RCompile.compile_restricted_eval))

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,6 +1,6 @@
-from . import compile
-from . import compile_eval
-from . import r_eval
+from . import c_eval
+from . import c_exec
+from . import e_eval
 from RestrictedPython import compile_restricted
 from RestrictedPython import CompileResult
 from RestrictedPython._compat import IS_PY2
@@ -23,10 +23,10 @@ def test_compile__compile_restricted_invalid_policy_input():
         compile_restricted("pass", '<string>', 'exec', policy=object())
 
 
-@pytest.mark.parametrize(*compile)
-def test_compile__compile_restricted_exec__1(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_compile__compile_restricted_exec__1(c_exec):
     """It returns a CompileResult on success."""
-    result = compile('a = 42')
+    result = c_exec('a = 42')
     assert result.__class__ == CompileResult
     assert result.errors == ()
     assert result.warnings == []
@@ -36,12 +36,12 @@ def test_compile__compile_restricted_exec__1(compile):
     assert glob['a'] == 42
 
 
-@pytest.mark.parametrize(*compile)
-def test_compile__compile_restricted_exec__2(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_compile__compile_restricted_exec__2(c_exec):
     """It compiles without restrictions if there is no policy."""
-    if compile is RestrictedPython.compile.compile_restricted_exec:
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
         # The old version does not support a custom policy
-        result = compile('_a = 42', policy=None)
+        result = c_exec('_a = 42', policy=None)
         assert result.errors == ()
         assert result.warnings == []
         assert result.used_names == {}
@@ -50,17 +50,17 @@ def test_compile__compile_restricted_exec__2(compile):
         assert glob['_a'] == 42
 
 
-@pytest.mark.parametrize(*compile)
-def test_compile__compile_restricted_exec__3(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_compile__compile_restricted_exec__3(c_exec):
     """It returns a tuple of errors if the code is not allowed.
 
     There is no code in this case.
     """
-    result = compile('_a = 42\n_b = 43')
+    result = c_exec('_a = 42\n_b = 43')
     errors = (
         'Line 1: "_a" is an invalid variable name because it starts with "_"',
         'Line 2: "_b" is an invalid variable name because it starts with "_"')
-    if compile is RestrictedPython.compile.compile_restricted_exec:
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
         assert result.errors == errors
     else:
         # The old version did only return the first error message.
@@ -70,14 +70,14 @@ def test_compile__compile_restricted_exec__3(compile):
     assert result.code is None
 
 
-@pytest.mark.parametrize(*compile)
-def test_compile__compile_restricted_exec__4(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_compile__compile_restricted_exec__4(c_exec):
     """It does not return code on a SyntaxError."""
-    result = compile('asdf|')
+    result = c_exec('asdf|')
     assert result.code is None
     assert result.warnings == []
     assert result.used_names == {}
-    if compile is RestrictedPython.compile.compile_restricted_exec:
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
         assert result.errors == (
             'Line 1: SyntaxError: invalid syntax in on statement: asdf|',)
     else:
@@ -85,10 +85,10 @@ def test_compile__compile_restricted_exec__4(compile):
         assert result.errors == ('invalid syntax (<string>, line 1)',)
 
 
-@pytest.mark.parametrize(*compile)
-def test_compile__compile_restricted_exec__5(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_compile__compile_restricted_exec__5(c_exec):
     """It does not return code if the code contains a NULL byte."""
-    result = compile('a = 5\x00')
+    result = c_exec('a = 5\x00')
     assert result.code is None
     assert result.warnings == []
     assert result.used_names == {}
@@ -109,10 +109,10 @@ def no_exec():
 @pytest.mark.skipif(
     IS_PY2,
     reason="exec statement in Python 2 is handled by RestrictedPython ")
-@pytest.mark.parametrize(*compile)
-def test_compile__compile_restricted_exec__10(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_compile__compile_restricted_exec__10(c_exec):
     """It is a SyntaxError to use the `exec` statement. (Python 3 only)"""
-    result = compile(EXEC_STATEMENT)
+    result = c_exec(EXEC_STATEMENT)
     assert (
         "Line 2: SyntaxError: Missing parentheses in call to 'exec' in on "
         "statement: exec 'q = 1'",) == result.errors
@@ -124,21 +124,21 @@ def a():
 """
 
 
-@pytest.mark.parametrize(*compile_eval)
-def test_compile__compile_restricted_eval__1(compile_eval):
+@pytest.mark.parametrize(*c_eval)
+def test_compile__compile_restricted_eval__1(c_eval):
     """It compiles code as an Expression.
 
     Function definitions are not allowed in Expressions.
     """
-    result = compile_eval(FUNCTION_DEF)
-    if compile_eval is RestrictedPython.compile.compile_restricted_eval:
+    result = c_eval(FUNCTION_DEF)
+    if c_eval is RestrictedPython.compile.compile_restricted_eval:
         assert result.errors == (
             'Line 1: SyntaxError: invalid syntax in on statement: def a():',)
     else:
         assert result.errors == ('invalid syntax (<string>, line 1)',)
 
 
-@pytest.mark.parametrize(*r_eval)
-def test_compile__compile_restricted_eval__2(r_eval):
+@pytest.mark.parametrize(*e_eval)
+def test_compile__compile_restricted_eval__2(e_eval):
     """It compiles code as an Expression."""
-    assert r_eval('4 * 6') == 24
+    assert e_eval('4 * 6') == 24

--- a/tests/test_print_stmt.py
+++ b/tests/test_print_stmt.py
@@ -1,4 +1,4 @@
-from RestrictedPython._compat import IS_PY2
+from . import c_exec
 from RestrictedPython._compat import IS_PY3
 from RestrictedPython.PrintCollector import PrintCollector
 
@@ -9,13 +9,6 @@ import RestrictedPython
 pytestmark = pytest.mark.skipif(
     IS_PY3,
     reason="print statement no longer exists in Python 3")
-
-
-compilers = ('compiler', [RestrictedPython.compile.compile_restricted_exec])
-
-if IS_PY2:
-    from RestrictedPython import RCompile
-    compilers[1].append(RCompile.compile_restricted_exec)
 
 
 ALLOWED_PRINT_STATEMENT = """
@@ -41,44 +34,44 @@ print('Hello World!', 'Hello Earth!')
 """
 
 
-@pytest.mark.parametrize(*compilers)
-def test_print_stmt__simple_prints(compiler):
+@pytest.mark.parametrize(*c_exec)
+def test_print_stmt__simple_prints(c_exec):
     glb = {'_print_': PrintCollector, '_getattr_': None}
 
-    code, errors = compiler(ALLOWED_PRINT_STATEMENT)[:2]
+    code, errors = c_exec(ALLOWED_PRINT_STATEMENT)[:2]
     assert code is not None
     assert errors == ()
     exec(code, glb)
     assert glb['_print']() == 'Hello World!\n'
 
-    code, errors = compiler(ALLOWED_PRINT_STATEMENT_WITH_NO_NL)[:2]
+    code, errors = c_exec(ALLOWED_PRINT_STATEMENT_WITH_NO_NL)[:2]
     assert code is not None
     assert errors == ()
     exec(code, glb)
     assert glb['_print']() == 'Hello World!'
 
-    code, errors = compiler(ALLOWED_MULTI_PRINT_STATEMENT)[:2]
+    code, errors = c_exec(ALLOWED_MULTI_PRINT_STATEMENT)[:2]
     assert code is not None
     assert errors == ()
     exec(code, glb)
     assert glb['_print']() == 'Hello World! Hello Earth!\n'
 
-    code, errors = compiler(ALLOWED_PRINT_TUPLE)[:2]
+    code, errors = c_exec(ALLOWED_PRINT_TUPLE)[:2]
     assert code is not None
     assert errors == ()
     exec(code, glb)
     assert glb['_print']() == "Hello World!\n"
 
-    code, errors = compiler(ALLOWED_PRINT_MULTI_TUPLE)[:2]
+    code, errors = c_exec(ALLOWED_PRINT_MULTI_TUPLE)[:2]
     assert code is not None
     assert errors == ()
     exec(code, glb)
     assert glb['_print']() == "('Hello World!', 'Hello Earth!')\n"
 
 
-@pytest.mark.parametrize(*compilers)
-def test_print_stmt__fail_with_none_target(compiler, mocker):
-    code, errors = compiler('print >> None, "test"')[:2]
+@pytest.mark.parametrize(*c_exec)
+def test_print_stmt__fail_with_none_target(c_exec, mocker):
+    code, errors = c_exec('print >> None, "test"')[:2]
 
     assert code is not None
     assert errors == ()
@@ -97,9 +90,9 @@ def print_into_stream(stream):
 """
 
 
-@pytest.mark.parametrize(*compilers)
-def test_print_stmt__protect_chevron_print(compiler, mocker):
-    code, errors = compiler(PROTECT_PRINT_STATEMENT_WITH_CHEVRON)[:2]
+@pytest.mark.parametrize(*c_exec)
+def test_print_stmt__protect_chevron_print(c_exec, mocker):
+    code, errors = c_exec(PROTECT_PRINT_STATEMENT_WITH_CHEVRON)[:2]
 
     _getattr_ = mocker.stub()
     _getattr_.side_effect = getattr
@@ -140,9 +133,9 @@ def main():
 """
 
 
-@pytest.mark.parametrize(*compilers)
-def test_print_stmt__nested_print_collector(compiler, mocker):
-    code, errors = compiler(INJECT_PRINT_COLLECTOR_NESTED)[:2]
+@pytest.mark.parametrize(*c_exec)
+def test_print_stmt__nested_print_collector(c_exec, mocker):
+    code, errors = c_exec(INJECT_PRINT_COLLECTOR_NESTED)[:2]
 
     glb = {"_print_": PrintCollector, '_getattr_': None}
     exec(code, glb)
@@ -157,18 +150,18 @@ def foo():
 """
 
 
-@pytest.mark.parametrize(*compilers)
-def test_print_stmt__with_printed_no_print(compiler):
-    code, errors, warnings = compiler(WARN_PRINTED_NO_PRINT)[:3]
+@pytest.mark.parametrize(*c_exec)
+def test_print_stmt__with_printed_no_print(c_exec):
+    code, errors, warnings = c_exec(WARN_PRINTED_NO_PRINT)[:3]
 
     assert code is not None
     assert errors == ()
 
-    if compiler is RestrictedPython.compile.compile_restricted_exec:
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
         assert warnings == [
             "Line 2: Doesn't print, but reads 'printed' variable."]
 
-    if compiler is RestrictedPython.RCompile.compile_restricted_exec:
+    if c_exec is RestrictedPython.RCompile.compile_restricted_exec:
         assert warnings == ["Doesn't print, but reads 'printed' variable."]
 
 
@@ -180,18 +173,18 @@ printed
 """
 
 
-@pytest.mark.parametrize(*compilers)
-def test_print_stmt__with_printed_no_print_nested(compiler):
-    code, errors, warnings = compiler(WARN_PRINTED_NO_PRINT_NESTED)[:3]
+@pytest.mark.parametrize(*c_exec)
+def test_print_stmt__with_printed_no_print_nested(c_exec):
+    code, errors, warnings = c_exec(WARN_PRINTED_NO_PRINT_NESTED)[:3]
 
     assert code is not None
     assert errors == ()
 
-    if compiler is RestrictedPython.compile.compile_restricted_exec:
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
         assert warnings == [
             "Line 3: Doesn't print, but reads 'printed' variable."]
 
-    if compiler is RestrictedPython.RCompile.compile_restricted_exec:
+    if c_exec is RestrictedPython.RCompile.compile_restricted_exec:
         assert warnings == ["Doesn't print, but reads 'printed' variable."]
 
 
@@ -201,18 +194,18 @@ def foo():
 """
 
 
-@pytest.mark.parametrize(*compilers)
-def test_print_stmt__with_print_no_printed(compiler):
-    code, errors, warnings = compiler(WARN_PRINT_NO_PRINTED)[:3]
+@pytest.mark.parametrize(*c_exec)
+def test_print_stmt__with_print_no_printed(c_exec):
+    code, errors, warnings = c_exec(WARN_PRINT_NO_PRINTED)[:3]
 
     assert code is not None
     assert errors == ()
 
-    if compiler is RestrictedPython.compile.compile_restricted_exec:
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
         assert warnings == [
             "Line 2: Prints, but never reads 'printed' variable."]
 
-    if compiler is RestrictedPython.RCompile.compile_restricted_exec:
+    if c_exec is RestrictedPython.RCompile.compile_restricted_exec:
         assert warnings == ["Prints, but never reads 'printed' variable."]
 
 
@@ -224,18 +217,18 @@ printed
 """
 
 
-@pytest.mark.parametrize(*compilers)
-def test_print_stmt__with_print_no_printed_nested(compiler):
-    code, errors, warnings = compiler(WARN_PRINT_NO_PRINTED_NESTED)[:3]
+@pytest.mark.parametrize(*c_exec)
+def test_print_stmt__with_print_no_printed_nested(c_exec):
+    code, errors, warnings = c_exec(WARN_PRINT_NO_PRINTED_NESTED)[:3]
 
     assert code is not None
     assert errors == ()
 
-    if compiler is RestrictedPython.compile.compile_restricted_exec:
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
         assert warnings == [
             "Line 3: Prints, but never reads 'printed' variable."]
 
-    if compiler is RestrictedPython.RCompile.compile_restricted_exec:
+    if c_exec is RestrictedPython.RCompile.compile_restricted_exec:
         assert warnings == ["Prints, but never reads 'printed' variable."]
 
 
@@ -252,9 +245,9 @@ def class_scope():
 """
 
 
-@pytest.mark.parametrize(*compilers)
-def test_print_stmt_no_new_scope(compiler):
-    code, errors = compiler(NO_PRINT_SCOPES)[:2]
+@pytest.mark.parametrize(*c_exec)
+def test_print_stmt_no_new_scope(c_exec):
+    code, errors = c_exec(NO_PRINT_SCOPES)[:2]
     glb = {'_print_': PrintCollector, '_getattr_': None}
     exec(code, glb)
 
@@ -270,9 +263,9 @@ def func(cond):
 """
 
 
-@pytest.mark.parametrize(*compilers)
-def test_print_stmt_conditional_print(compiler):
-    code, errors = compiler(CONDITIONAL_PRINT)[:2]
+@pytest.mark.parametrize(*c_exec)
+def test_print_stmt_conditional_print(c_exec):
+    code, errors = c_exec(CONDITIONAL_PRINT)[:2]
     glb = {'_print_': PrintCollector, '_getattr_': None}
     exec(code, glb)
 

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,5 +1,5 @@
-from . import compile
-from . import execute
+from . import c_exec
+from . import e_exec
 from RestrictedPython import RestrictingNodeTransformer
 from RestrictedPython._compat import IS_PY2
 from RestrictedPython._compat import IS_PY3
@@ -26,45 +26,45 @@ def test_transformer__RestrictingNodeTransformer__generic_visit__1():
         'Line None: MyFancyNode statement is not known to RestrictedPython']
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_Num__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Num__1(e_exec):
     """It allows to use number literals."""
-    glb = execute('a = 42')
+    glb = e_exec('a = 42')
     assert glb['a'] == 42
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_Bytes__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Bytes__1(e_exec):
     """It allows to use bytes literals."""
-    glb = execute('a = b"code"')
+    glb = e_exec('a = b"code"')
     assert glb['a'] == b"code"
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_Set__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Set__1(e_exec):
     """It allows to use bytes literals."""
-    glb = execute('a = {1, 2, 3}')
+    glb = e_exec('a = {1, 2, 3}')
     assert glb['a'] == set([1, 2, 3])
 
 
 @pytest.mark.skipif(IS_PY2,
                     reason="... is new in Python 3")
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Ellipsis__1(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Ellipsis__1(c_exec):
     """It prevents using the `ellipsis` statement."""
-    result = compile('...')
+    result = c_exec('...')
     assert result.errors == ('Line 1: Ellipsis statements are not allowed.',)
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Call__1(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Call__1(c_exec):
     """It compiles a function call successfully and returns the used name."""
-    result = compile('a = max([1, 2, 3])')
+    result = c_exec('a = max([1, 2, 3])')
     assert result.errors == ()
     loc = {}
     exec(result.code, {}, loc)
     assert loc['a'] == 3
-    if compile is RestrictedPython.compile.compile_restricted_exec:
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
         # The new version not yet supports `used_names`:
         assert result.used_names == {}
     else:
@@ -77,10 +77,10 @@ def no_yield():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Yield__1(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Yield__1(c_exec):
     """It prevents using the `yield` statement."""
-    result = compile(YIELD)
+    result = c_exec(YIELD)
     assert result.errors == ("Line 2: Yield statements are not allowed.",)
 
 
@@ -92,10 +92,10 @@ def no_exec():
 
 @pytest.mark.skipif(IS_PY3,
                     reason="exec statement no longer exists in Python 3")
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Exec__1(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Exec__1(c_exec):
     """It prevents using the `exec` statement. (Python 2 only)"""
-    result = compile(EXEC_STATEMENT)
+    result = c_exec(EXEC_STATEMENT)
     assert result.errors == ('Line 2: Exec statements are not allowed.',)
 
 
@@ -105,10 +105,10 @@ def bad_name():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Name__1(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Name__1(c_exec):
     """It denies a variable name starting in `__`."""
-    result = compile(BAD_NAME_STARTING_WITH_UNDERSCORE)
+    result = c_exec(BAD_NAME_STARTING_WITH_UNDERSCORE)
     assert result.errors == (
         'Line 2: "__" is an invalid variable name because it starts with "_"',)
 
@@ -119,10 +119,10 @@ def overrideGuardWithName():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Name__2(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Name__2(c_exec):
     """It denies a variable name starting in `_`."""
-    result = compile(BAD_NAME_OVERRIDE_GUARD_WITH_NAME)
+    result = c_exec(BAD_NAME_OVERRIDE_GUARD_WITH_NAME)
     assert result.errors == (
         'Line 2: "_getattr" is an invalid variable name because '
         'it starts with "_"',)
@@ -135,10 +135,10 @@ def overrideGuardWithFunction():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Name__3(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Name__3(c_exec):
     """It denies a function name starting in `_`."""
-    result = compile(BAD_NAME_OVERRIDE_OVERRIDE_GUARD_WITH_FUNCTION)
+    result = c_exec(BAD_NAME_OVERRIDE_OVERRIDE_GUARD_WITH_FUNCTION)
     assert result.errors == (
         'Line 2: "_getattr" is an invalid variable name because it '
         'starts with "_"',)
@@ -151,10 +151,10 @@ def overrideGuardWithClass():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Name__4(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Name__4(c_exec):
     """It denies a class name starting in `_`."""
-    result = compile(BAD_NAME_OVERRIDE_GUARD_WITH_CLASS)
+    result = c_exec(BAD_NAME_OVERRIDE_GUARD_WITH_CLASS)
     assert result.errors == (
         'Line 2: "_getattr" is an invalid variable name because it '
         'starts with "_"',)
@@ -167,10 +167,10 @@ def with_as_bad_name():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Name__4_4(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Name__4_4(c_exec):
     """It denies a variable name in with starting in `_`."""
-    result = compile(BAD_NAME_IN_WITH)
+    result = c_exec(BAD_NAME_IN_WITH)
     assert result.errors == (
         'Line 2: "_leading_underscore" is an invalid variable name because '
         'it starts with "_"',)
@@ -183,10 +183,10 @@ def compound_with_bad_name():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Name__4_5(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Name__4_5(c_exec):
     """It denies a variable name in with starting in `_`."""
-    result = compile(BAD_NAME_IN_COMPOUND_WITH)
+    result = c_exec(BAD_NAME_IN_COMPOUND_WITH)
     assert result.errors == (
         'Line 2: "_restricted_name" is an invalid variable name because '
         'it starts with "_"',)
@@ -198,10 +198,10 @@ def dict_comp_bad_name():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Name__4_6(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Name__4_6(c_exec):
     """It denies a variable name starting in `_` in a dict comprehension."""
-    result = compile(BAD_NAME_DICT_COMP)
+    result = c_exec(BAD_NAME_DICT_COMP)
     assert result.errors == (
         'Line 2: "_restricted_name" is an invalid variable name because '
         'it starts with "_"',)
@@ -213,10 +213,10 @@ def set_comp_bad_name():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Name__4_7(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Name__4_7(c_exec):
     """It denies a variable name starting in `_` in a dict comprehension."""
-    result = compile(BAD_NAME_SET_COMP)
+    result = c_exec(BAD_NAME_SET_COMP)
     assert result.errors == (
         'Line 2: "_restricted_name" is an invalid variable name because '
         'it starts with "_"',)
@@ -228,10 +228,10 @@ def bad_name():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Name__5(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Name__5(c_exec):
     """It denies a variable name ending in `__roles__`."""
-    result = compile(BAD_NAME_ENDING_WITH___ROLES__)
+    result = c_exec(BAD_NAME_ENDING_WITH___ROLES__)
     assert result.errors == (
         'Line 2: "myvar__roles__" is an invalid variable name because it '
         'ends with "__roles__".',)
@@ -243,10 +243,10 @@ def bad_name():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Name__6(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Name__6(c_exec):
     """It denies a variable named `printed`."""
-    result = compile(BAD_NAME_PRINTED)
+    result = c_exec(BAD_NAME_PRINTED)
     assert result.errors == ('Line 2: "printed" is a reserved name.',)
 
 
@@ -259,10 +259,10 @@ def bad_name():
 
 @pytest.mark.skipif(IS_PY2,
                     reason="print is a statement in Python 2")
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Name__7(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Name__7(c_exec):
     """It denies a variable named `print`."""
-    result = compile(BAD_NAME_PRINT)
+    result = c_exec(BAD_NAME_PRINT)
     assert result.errors == ('Line 2: "print" is a reserved name.',)
 
 
@@ -273,10 +273,10 @@ def bad_attr():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Attribute__1(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Attribute__1(c_exec):
     """It is an error if a bad attribute name is used."""
-    result = compile(BAD_ATTR_UNDERSCORE)
+    result = c_exec(BAD_ATTR_UNDERSCORE)
     assert result.errors == (
         'Line 3: "_some_attr" is an invalid attribute name because it '
         'starts with "_".',)
@@ -289,10 +289,10 @@ def bad_attr():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Attribute__2(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Attribute__2(c_exec):
     """It is an error if a bad attribute name is used."""
-    result = compile(BAD_ATTR_ROLES)
+    result = c_exec(BAD_ATTR_ROLES)
     assert result.errors == (
         'Line 3: "abc__roles__" is an invalid attribute name because it '
         'ends with "__roles__".',)
@@ -304,10 +304,10 @@ def func():
 """
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_Attribute__3(
-        compile, mocker):
-    result = compile(TRANSFORM_ATTRIBUTE_ACCESS)
+        c_exec, mocker):
+    result = c_exec(TRANSFORM_ATTRIBUTE_ACCESS)
     assert result.errors == ()
 
     glb = {
@@ -329,10 +329,10 @@ def func():
 """
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_Attribute__4(
-        compile, mocker):
-    result = compile(ALLOW_UNDERSCORE_ONLY)
+        c_exec, mocker):
+    result = c_exec(ALLOW_UNDERSCORE_ONLY)
     assert result.errors == ()
 
 
@@ -342,10 +342,10 @@ def func():
 """
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_Attribute__5(
-        compile, mocker):
-    result = compile(TRANSFORM_ATTRIBUTE_WRITE)
+        c_exec, mocker):
+    result = c_exec(TRANSFORM_ATTRIBUTE_WRITE)
     assert result.errors == ()
 
     glb = {
@@ -375,9 +375,9 @@ except Exception as e:
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Attribute__6(compile):
-    result = compile(DISALLOW_TRACEBACK_ACCESS)
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Attribute__6(c_exec):
+    result = c_exec(DISALLOW_TRACEBACK_ACCESS)
     assert result.errors == (
         'Line 5: "__traceback__" is an invalid attribute name because '
         'it starts with "_".',)
@@ -391,10 +391,10 @@ lambda_default = lambda x=b.b: x
 """
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_Attribute__7(
-        compile, mocker):
-    result = compile(TRANSFORM_ATTRIBUTE_ACCESS_FUNCTION_DEFAULT)
+        c_exec, mocker):
+    result = c_exec(TRANSFORM_ATTRIBUTE_ACCESS_FUNCTION_DEFAULT)
     assert result.errors == ()
 
     _getattr_ = mocker.Mock()
@@ -422,10 +422,10 @@ def test_transformer__RestrictingNodeTransformer__visit_Attribute__7(
 
 @pytest.mark.skipif(IS_PY2,
                     reason="exec is a statement in Python 2")
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Call__2(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Call__2(c_exec):
     """It is an error if the code call the `exec` function."""
-    result = compile(EXEC_FUNCTION)
+    result = c_exec(EXEC_FUNCTION)
     assert result.errors == ("Line 2: Exec calls are not allowed.",)
 
 
@@ -435,11 +435,11 @@ def no_eval():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Call__3(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Call__3(c_exec):
     """It is an error if the code call the `eval` function."""
-    result = compile(EVAL_FUNCTION)
-    if compile is RestrictedPython.compile.compile_restricted_exec:
+    result = c_exec(EVAL_FUNCTION)
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
         assert result.errors == ("Line 2: Eval calls are not allowed.",)
     else:
         # `eval()` is allowed in the old implementation. :-(
@@ -481,9 +481,9 @@ def nested_generator(it1, it2):
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__guard_iter(compile, mocker):
-    result = compile(ITERATORS)
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__guard_iter(c_exec, mocker):
+    result = c_exec(ITERATORS)
     assert result.errors == ()
 
     it = (1, 2, 3)
@@ -565,9 +565,9 @@ def generator(it):
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__guard_iter2(compile, mocker):
-    result = compile(ITERATORS_WITH_UNPACK_SEQUENCE)
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__guard_iter2(c_exec, mocker):
+    result = c_exec(ITERATORS_WITH_UNPACK_SEQUENCE)
     assert result.errors == ()
 
     it = ((1, 2), (3, 4), (5, 6))
@@ -641,10 +641,10 @@ def extended_slice_subscript(a):
 """
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_Subscript_1(
-        compile, mocker):
-    result = compile(GET_SUBSCRIPTS)
+        c_exec, mocker):
+    result = c_exec(GET_SUBSCRIPTS)
     assert result.errors == ()
 
     value = None
@@ -715,10 +715,10 @@ def del_subscript(a):
 """
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_Subscript_2(
-        compile, mocker):
-    result = compile(WRITE_SUBSCRIPTS)
+        c_exec, mocker):
+    result = c_exec(WRITE_SUBSCRIPTS)
     assert result.errors == ()
 
     value = {'b': None}
@@ -738,9 +738,9 @@ def test_transformer__RestrictingNodeTransformer__visit_Subscript_2(
     _write_.reset_mock()
 
 
-@pytest.mark.parametrize(*execute)
+@pytest.mark.parametrize(*e_exec)
 def test_transformer__RestrictingNodeTransformer__visit_AugAssign__1(
-        execute, mocker):
+        e_exec, mocker):
     """It allows augmented assign for variables."""
     _inplacevar_ = mocker.stub()
     _inplacevar_.side_effect = lambda op, val, expr: val + expr
@@ -752,51 +752,51 @@ def test_transformer__RestrictingNodeTransformer__visit_AugAssign__1(
         'z': 0
     }
 
-    execute("a += x + z", glb)
+    e_exec("a += x + z", glb)
     assert glb['a'] == 2
     _inplacevar_.assert_called_once_with('+=', 1, 1)
     _inplacevar_.reset_mock()
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_AugAssign__2(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_AugAssign__2(c_exec):
     """It forbids augmented assign of attributes."""
-    result = compile("a.a += 1")
+    result = c_exec("a.a += 1")
     assert result.errors == (
         'Line 1: Augmented assignment of attributes is not allowed.',)
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_AugAssign__3(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_AugAssign__3(c_exec):
     """It forbids augmented assign of subscripts."""
-    result = compile("a[a] += 1")
+    result = c_exec("a[a] += 1")
     assert result.errors == (
         'Line 1: Augmented assignment of object items and slices is not '
         'allowed.',)
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_AugAssign__4(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_AugAssign__4(c_exec):
     """It forbids augmented assign of slices."""
-    result = compile("a[x:y] += 1")
+    result = c_exec("a[x:y] += 1")
     assert result.errors == (
         'Line 1: Augmented assignment of object items and slices is not '
         'allowed.',)
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_AugAssign__5(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_AugAssign__5(c_exec):
     """It forbids augmented assign of slices with steps."""
-    result = compile("a[x:y:z] += 1")
+    result = c_exec("a[x:y:z] += 1")
     assert result.errors == (
         'Line 1: Augmented assignment of object items and slices is not '
         'allowed.',)
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_Assert__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Assert__1(e_exec):
     """It allows assert statements."""
-    execute('assert 1')
+    e_exec('assert 1')
 
 
 # def f(a, b, c): pass
@@ -834,9 +834,9 @@ def positional_and_star_and_keyword_and_kw_args():
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Call(compile, mocker):
-    result = compile(FUNCTIONC_CALLS)
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Call(c_exec, mocker):
+    result = c_exec(FUNCTIONC_CALLS)
     assert result.errors == ()
 
     _apply_ = mocker.stub()
@@ -895,52 +895,52 @@ functiondef_err_msg = 'Line 1: "_bad" is an invalid variable ' \
                       'name because it starts with "_"'
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_FunctionDef__1(
-        compile):
+        c_exec):
     """It prevents function arguments starting with `_`."""
-    result = compile("def foo(_bad): pass")
+    result = c_exec("def foo(_bad): pass")
     # RestrictedPython.compile.compile_restricted_exec on Python 2 renders
     # the error message twice. This is necessary as otherwise *_bad and **_bad
     # would be allowed.
     assert functiondef_err_msg in result.errors
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_FunctionDef__2(
-        compile):
+        c_exec):
     """It prevents function keyword arguments starting with `_`."""
-    result = compile("def foo(_bad=1): pass")
+    result = c_exec("def foo(_bad=1): pass")
     # RestrictedPython.compile.compile_restricted_exec on Python 2 renders
     # the error message twice. This is necessary as otherwise *_bad and **_bad
     # would be allowed.
     assert functiondef_err_msg in result.errors
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_FunctionDef__3(
-        compile):
+        c_exec):
     """It prevents function * arguments starting with `_`."""
-    result = compile("def foo(*_bad): pass")
+    result = c_exec("def foo(*_bad): pass")
     assert result.errors == (functiondef_err_msg,)
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_FunctionDef__4(
-        compile):
+        c_exec):
     """It prevents function ** arguments starting with `_`."""
-    result = compile("def foo(**_bad): pass")
+    result = c_exec("def foo(**_bad): pass")
     assert result.errors == (functiondef_err_msg,)
 
 
 @pytest.mark.skipif(
     IS_PY3,
     reason="tuple parameter unpacking is gone in Python 3")
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_FunctionDef__5(
-        compile):
+        c_exec):
     """It prevents function arguments starting with `_` in tuples."""
-    result = compile("def foo((a, _bad)): pass")
+    result = c_exec("def foo((a, _bad)): pass")
     # RestrictedPython.compile.compile_restricted_exec on Python 2 renders
     # the error message twice. This is necessary as otherwise *_bad and **_bad
     # would be allowed.
@@ -950,13 +950,13 @@ def test_transformer__RestrictingNodeTransformer__visit_FunctionDef__5(
 @pytest.mark.skipif(
     IS_PY3,
     reason="tuple parameter unpacking is gone in Python 3")
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_FunctionDef__6(
-        compile):
+        c_exec):
     """It prevents function arguments starting with `_` in tuples."""
     # The old `compile` breaks with tuples in function arguments:
-    if compile is RestrictedPython.compile.compile_restricted_exec:
-        result = compile("def foo(a, (c, (_bad, c))): pass")
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
+        result = c_exec("def foo(a, (c, (_bad, c))): pass")
         # RestrictedPython.compile.compile_restricted_exec on Python 2 renders
         # the error message twice. This is necessary as otherwise *_bad and
         # **_bad would be allowed.
@@ -966,11 +966,11 @@ def test_transformer__RestrictingNodeTransformer__visit_FunctionDef__6(
 @pytest.mark.skipif(
     IS_PY2,
     reason="There is no single `*` argument in Python 2")
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_FunctionDef__7(
-        compile):
+        c_exec):
     """It prevents `_` function arguments together with a single `*`."""
-    result = compile("def foo(good, *, _bad): pass")
+    result = c_exec("def foo(good, *, _bad): pass")
     assert result.errors == (functiondef_err_msg,)
 
 
@@ -986,10 +986,10 @@ def nested_with_order((a, b), (c, d)):
 @pytest.mark.skipif(
     IS_PY3,
     reason="tuple parameter unpacking is gone in python 3")
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_FunctionDef_2(
-        compile, mocker):
-    result = compile('def simple((a, b)): return a, b')
+        c_exec, mocker):
+    result = c_exec('def simple((a, b)): return a, b')
     assert result.errors == ()
 
     _getiter_ = mocker.stub()
@@ -1009,10 +1009,10 @@ def test_transformer__RestrictingNodeTransformer__visit_FunctionDef_2(
     _getiter_.reset_mock()
 
     # The old RCompile did not support nested.
-    if compile is RestrictedPython.RCompile.compile_restricted_exec:
+    if c_exec is RestrictedPython.RCompile.compile_restricted_exec:
         return
 
-    result = compile(NESTED_SEQ_UNPACK)
+    result = c_exec(NESTED_SEQ_UNPACK)
     assert result.errors == ()
     exec(result.code, glb)
 
@@ -1037,49 +1037,49 @@ lambda_err_msg = 'Line 1: "_bad" is an invalid variable ' \
                  'name because it starts with "_"'
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Lambda__1(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Lambda__1(c_exec):
     """It prevents arguments starting with `_`."""
-    result = compile("lambda _bad: None")
+    result = c_exec("lambda _bad: None")
     # RestrictedPython.compile.compile_restricted_exec on Python 2 renders
     # the error message twice. This is necessary as otherwise *_bad and **_bad
     # would be allowed.
     assert lambda_err_msg in result.errors
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Lambda__2(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Lambda__2(c_exec):
     """It prevents keyword arguments starting with `_`."""
-    result = compile("lambda _bad=1: None")
+    result = c_exec("lambda _bad=1: None")
     # RestrictedPython.compile.compile_restricted_exec on Python 2 renders
     # the error message twice. This is necessary as otherwise *_bad and **_bad
     # would be allowed.
     assert lambda_err_msg in result.errors
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Lambda__3(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Lambda__3(c_exec):
     """It prevents * arguments starting with `_`."""
-    result = compile("lambda *_bad: None")
+    result = c_exec("lambda *_bad: None")
     assert result.errors == (lambda_err_msg,)
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Lambda__4(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Lambda__4(c_exec):
     """It prevents ** arguments starting with `_`."""
-    result = compile("lambda **_bad: None")
+    result = c_exec("lambda **_bad: None")
     assert result.errors == (lambda_err_msg,)
 
 
 @pytest.mark.skipif(
     IS_PY3,
     reason="tuple parameter unpacking is gone in Python 3")
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Lambda__5(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Lambda__5(c_exec):
     """It prevents arguments starting with `_` in tuple unpacking."""
     # The old `compile` breaks with tuples in arguments:
-    if compile is RestrictedPython.compile.compile_restricted_exec:
-        result = compile("lambda (a, _bad): None")
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
+        result = c_exec("lambda (a, _bad): None")
         # RestrictedPython.compile.compile_restricted_exec on Python 2 renders
         # the error message twice. This is necessary as otherwise *_bad and
         # **_bad would be allowed.
@@ -1089,12 +1089,12 @@ def test_transformer__RestrictingNodeTransformer__visit_Lambda__5(compile):
 @pytest.mark.skipif(
     IS_PY3,
     reason="tuple parameter unpacking is gone in Python 3")
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Lambda__6(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Lambda__6(c_exec):
     """It prevents arguments starting with `_` in nested tuple unpacking."""
     # The old `compile` breaks with tuples in arguments:
-    if compile is RestrictedPython.compile.compile_restricted_exec:
-        result = compile("lambda (a, (c, (_bad, c))): None")
+    if c_exec is RestrictedPython.compile.compile_restricted_exec:
+        result = c_exec("lambda (a, (c, (_bad, c))): None")
         # RestrictedPython.compile.compile_restricted_exec on Python 2 renders
         # the error message twice. This is necessary as otherwise *_bad and
         # **_bad would be allowed.
@@ -1104,10 +1104,10 @@ def test_transformer__RestrictingNodeTransformer__visit_Lambda__6(compile):
 @pytest.mark.skipif(
     IS_PY2,
     reason="There is no single `*` argument in Python 2")
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Lambda__7(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Lambda__7(c_exec):
     """It prevents arguments starting with `_` together with a single `*`."""
-    result = compile("lambda good, *, _bad: None")
+    result = c_exec("lambda good, *, _bad: None")
     assert result.errors == (lambda_err_msg,)
 
 
@@ -1117,10 +1117,10 @@ def check_getattr_in_lambda(arg=lambda _bad=(lambda ob, name: name): _bad2):
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Lambda__8(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Lambda__8(c_exec):
     """It prevents arguments starting with `_` in weird lambdas."""
-    result = compile(BAD_ARG_IN_LAMBDA)
+    result = c_exec(BAD_ARG_IN_LAMBDA)
     # RestrictedPython.compile.compile_restricted_exec finds both invalid
     # names, while the old implementation seems to abort after the first.
     assert lambda_err_msg in result.errors
@@ -1129,10 +1129,10 @@ def test_transformer__RestrictingNodeTransformer__visit_Lambda__8(compile):
 @pytest.mark.skipif(
     IS_PY3,
     reason="tuple parameter unpacking is gone in python 3")
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_Lambda_2(
-        compile, mocker):
-    if compile is not RestrictedPython.compile.compile_restricted_exec:
+        c_exec, mocker):
+    if c_exec is not RestrictedPython.compile.compile_restricted_exec:
         return
 
     _getiter_ = mocker.stub()
@@ -1144,7 +1144,7 @@ def test_transformer__RestrictingNodeTransformer__visit_Lambda_2(
     }
 
     src = "m = lambda (a, (b, c)), *ag, **kw: a+b+c+sum(ag)+sum(kw.values())"
-    result = compile(src)
+    result = c_exec(src)
     assert result.errors == ()
     exec(result.code, glb)
 
@@ -1155,11 +1155,11 @@ def test_transformer__RestrictingNodeTransformer__visit_Lambda_2(
     _getiter_.assert_any_call((2, 3))
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_Assign(
-        compile, mocker):
+        c_exec, mocker):
     src = "orig = (a, (x, z)) = (c, d) = g"
-    result = compile(src)
+    result = c_exec(src)
     assert result.errors == ()
 
     _getiter_ = mocker.stub()
@@ -1187,11 +1187,11 @@ def test_transformer__RestrictingNodeTransformer__visit_Assign(
 @pytest.mark.skipif(
     IS_PY2,
     reason="starred assignments are python3 only")
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_Assign2(
-        compile, mocker):
+        c_exec, mocker):
     src = "a, *d, (c, *e), x  = (1, 2, 3, (4, 3, 4), 5)"
-    result = compile(src)
+    result = c_exec(src)
     assert result.errors == ()
 
     _getiter_ = mocker.stub()
@@ -1225,12 +1225,12 @@ def try_except(m):
 """
 
 
-@pytest.mark.parametrize(*execute)
+@pytest.mark.parametrize(*e_exec)
 def test_transformer__RestrictingNodeTransformer__visit_Try__1(
-        execute, mocker):
+        e_exec, mocker):
     """It allows try-except statements."""
     trace = mocker.stub()
-    execute(TRY_EXCEPT)['try_except'](trace)
+    e_exec(TRY_EXCEPT)['try_except'](trace)
 
     trace.assert_has_calls([
         mocker.call('try'),
@@ -1249,12 +1249,12 @@ def try_except_else(m):
 """
 
 
-@pytest.mark.parametrize(*execute)
+@pytest.mark.parametrize(*e_exec)
 def test_transformer__RestrictingNodeTransformer__visit_Try__2(
-        execute, mocker):
+        e_exec, mocker):
     """It allows try-except-else statements."""
     trace = mocker.stub()
-    execute(TRY_EXCEPT_ELSE)['try_except_else'](trace)
+    e_exec(TRY_EXCEPT_ELSE)['try_except_else'](trace)
 
     trace.assert_has_calls([
         mocker.call('try'),
@@ -1273,12 +1273,12 @@ def try_finally(m):
 """
 
 
-@pytest.mark.parametrize(*execute)
+@pytest.mark.parametrize(*e_exec)
 def test_transformer__RestrictingNodeTransformer__visit_TryFinally__1(
-        execute, mocker):
+        e_exec, mocker):
     """It allows try-finally statements."""
     trace = mocker.stub()
-    execute(TRY_FINALLY)['try_finally'](trace)
+    e_exec(TRY_FINALLY)['try_finally'](trace)
 
     trace.assert_has_calls([
         mocker.call('try'),
@@ -1298,12 +1298,12 @@ def try_except_finally(m):
 """
 
 
-@pytest.mark.parametrize(*execute)
+@pytest.mark.parametrize(*e_exec)
 def test_transformer__RestrictingNodeTransformer__visit_TryFinally__2(
-        execute, mocker):
+        e_exec, mocker):
     """It allows try-except-finally statements."""
     trace = mocker.stub()
-    execute(TRY_EXCEPT_FINALLY)['try_except_finally'](trace)
+    e_exec(TRY_EXCEPT_FINALLY)['try_except_finally'](trace)
 
     trace.assert_has_calls([
         mocker.call('try'),
@@ -1325,12 +1325,12 @@ def try_except_else_finally(m):
 """
 
 
-@pytest.mark.parametrize(*execute)
+@pytest.mark.parametrize(*e_exec)
 def test_transformer__RestrictingNodeTransformer__visit_TryFinally__3(
-        execute, mocker):
+        e_exec, mocker):
     """It allows try-except-else-finally statements."""
     trace = mocker.stub()
-    execute(TRY_EXCEPT_ELSE_FINALLY)['try_except_else_finally'](trace)
+    e_exec(TRY_EXCEPT_ELSE_FINALLY)['try_except_else_finally'](trace)
 
     trace.assert_has_calls([
         mocker.call('try'),
@@ -1351,10 +1351,10 @@ def tuple_unpack(err):
 @pytest.mark.skipif(
     IS_PY3,
     reason="tuple unpacking on exceptions is gone in python3")
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_ExceptHandler(
-        compile, mocker):
-    result = compile(EXCEPT_WITH_TUPLE_UNPACK)
+        c_exec, mocker):
+    result = c_exec(EXCEPT_WITH_TUPLE_UNPACK)
     assert result.errors == ()
 
     _getiter_ = mocker.stub()
@@ -1387,11 +1387,11 @@ def except_using_bad_name():
 """
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__visit_ExceptHandler__2(
-        compile):
+        c_exec):
     """It denies bad names in the except as statement."""
-    result = compile(BAD_TRY_EXCEPT)
+    result = c_exec(BAD_TRY_EXCEPT)
     assert result.errors == (
         'Line 5: "_leading_underscore" is an invalid variable name because '
         'it starts with "_"',)
@@ -1401,89 +1401,89 @@ import_errmsg = (
     'Line 1: "%s" is an invalid variable name because it starts with "_"')
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Import__1(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Import__1(c_exec):
     """It allows importing a module."""
-    result = compile('import a')
+    result = c_exec('import a')
     assert result.errors == ()
     assert result.code is not None
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Import__2(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Import__2(c_exec):
     """It denies importing a module starting with `_`."""
-    result = compile('import _a')
+    result = c_exec('import _a')
     assert result.errors == (import_errmsg % '_a',)
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Import__3(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Import__3(c_exec):
     """It denies importing a module starting with `_` as something."""
-    result = compile('import _a as m')
+    result = c_exec('import _a as m')
     assert result.errors == (import_errmsg % '_a',)
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Import__4(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Import__4(c_exec):
     """It denies importing a module as something starting with `_`."""
-    result = compile('import a as _m')
+    result = c_exec('import a as _m')
     assert result.errors == (import_errmsg % '_m',)
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Import__5(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Import__5(c_exec):
     """It allows importing from a module."""
-    result = compile('from a import m')
+    result = c_exec('from a import m')
     assert result.errors == ()
     assert result.code is not None
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Import_6(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Import_6(c_exec):
     """It allows importing from a module starting with `_`."""
-    result = compile('from _a import m')
+    result = c_exec('from _a import m')
     assert result.errors == ()
     assert result.code is not None
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Import__7(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Import__7(c_exec):
     """It denies importing from a module as something starting with `_`."""
-    result = compile('from a import m as _n')
+    result = c_exec('from a import m as _n')
     assert result.errors == (import_errmsg % '_n',)
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Import__8(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Import__8(c_exec):
     """It denies as-importing something starting with `_` from a module."""
-    result = compile('from a import _m as n')
+    result = c_exec('from a import _m as n')
     assert result.errors == (import_errmsg % '_m',)
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_Import__9(compile):
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Import__9(c_exec):
     """It denies relative from importing as something starting with `_`."""
-    result = compile('from .x import y as _leading_underscore')
+    result = c_exec('from .x import y as _leading_underscore')
     assert result.errors == (import_errmsg % '_leading_underscore',)
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__RestrictingNodeTransformer__visit_ClassDef(compile):
-    result = compile('class Good: pass')
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__RestrictingNodeTransformer__visit_ClassDef(c_exec):
+    result = c_exec('class Good: pass')
     assert result.errors == ()
     assert result.code is not None
 
     # Do not allow class names which start with an underscore.
-    result = compile('class _bad: pass')
+    result = c_exec('class _bad: pass')
     assert result.errors == (
         'Line 1: "_bad" is an invalid variable name '
         'because it starts with "_"',)
 
 
-@pytest.mark.parametrize(*compile)
+@pytest.mark.parametrize(*c_exec)
 def test_transformer__RestrictingNodeTransformer__test_ternary_if(
-        compile, mocker):
-    result = compile('x.y = y.a if y.z else y.b')
+        c_exec, mocker):
+    result = c_exec('x.y = y.a if y.z else y.b')
     assert result.errors == ()
 
     _getattr_ = mocker.stub()
@@ -1527,10 +1527,10 @@ while a < 7:
 """
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_While__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_While__1(e_exec):
     """It allows `while` statements."""
-    glb = execute(WHILE)
+    glb = e_exec(WHILE)
     assert glb['a'] == 8
 
 
@@ -1543,10 +1543,10 @@ while True:
 """
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_Break__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Break__1(e_exec):
     """It allows `break` statements."""
-    glb = execute(BREAK)
+    glb = e_exec(BREAK)
     assert glb['a'] == 8
 
 
@@ -1560,10 +1560,10 @@ while a < 10:
 """
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_Continue__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Continue__1(e_exec):
     """It allows `continue` statements."""
-    glb = execute(CONTINUE)
+    glb = e_exec(CONTINUE)
     assert glb['a'] == 15
 
 
@@ -1574,9 +1574,9 @@ def call(ctx):
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__with_stmt_unpack_sequence(compile, mocker):
-    result = compile(WITH_STMT_WITH_UNPACK_SEQUENCE)
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__with_stmt_unpack_sequence(c_exec, mocker):
+    result = c_exec(WITH_STMT_WITH_UNPACK_SEQUENCE)
     assert result.errors == ()
 
     @contextlib.contextmanager
@@ -1608,9 +1608,9 @@ def call(ctx1, ctx2):
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer__with_stmt_multi_ctx_unpack_sequence(compile, mocker):
-    result = compile(WITH_STMT_MULTI_CTX_WITH_UNPACK_SEQUENCE)
+@pytest.mark.parametrize(*c_exec)
+def test_transformer__with_stmt_multi_ctx_unpack_sequence(c_exec, mocker):
+    result = c_exec(WITH_STMT_MULTI_CTX_WITH_UNPACK_SEQUENCE)
     assert result.errors == ()
 
     @contextlib.contextmanager
@@ -1659,9 +1659,9 @@ def load_attr(w):
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer_with_stmt_attribute_access(compile, mocker):
-    result = compile(WITH_STMT_ATTRIBUTE_ACCESS)
+@pytest.mark.parametrize(*c_exec)
+def test_transformer_with_stmt_attribute_access(c_exec, mocker):
+    result = c_exec(WITH_STMT_ATTRIBUTE_ACCESS)
     assert result.errors == ()
 
     _getattr_ = mocker.stub()
@@ -1724,9 +1724,9 @@ def slice_key(ctx, x):
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer_with_stmt_subscript(compile, mocker):
-    result = compile(WITH_STMT_SUBSCRIPT)
+@pytest.mark.parametrize(*c_exec)
+def test_transformer_with_stmt_subscript(c_exec, mocker):
+    result = c_exec(WITH_STMT_SUBSCRIPT)
     assert result.errors == ()
 
     _write_ = mocker.stub()
@@ -1763,9 +1763,9 @@ def call(seq):
 """
 
 
-@pytest.mark.parametrize(*compile)
-def test_transformer_dict_comprehension_with_attrs(compile, mocker):
-    result = compile(DICT_COMPREHENSION_WITH_ATTRS)
+@pytest.mark.parametrize(*c_exec)
+def test_transformer_dict_comprehension_with_attrs(c_exec, mocker):
+    result = c_exec(DICT_COMPREHENSION_WITH_ATTRS)
     assert result.errors == ()
 
     _getattr_ = mocker.Mock()
@@ -1793,71 +1793,71 @@ def test_transformer_dict_comprehension_with_attrs(compile, mocker):
     ])
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_Eq__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Eq__1(e_exec):
     """It allows == expressions."""
-    glb = execute('a = (1 == int("1"))')
+    glb = e_exec('a = (1 == int("1"))')
     assert glb['a'] is True
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_NotEq__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_NotEq__1(e_exec):
     """It allows != expressions."""
-    glb = execute('a = (1 != int("1"))')
+    glb = e_exec('a = (1 != int("1"))')
     assert glb['a'] is False
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_Lt__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Lt__1(e_exec):
     """It allows < expressions."""
-    glb = execute('a = (1 < 3)')
+    glb = e_exec('a = (1 < 3)')
     assert glb['a'] is True
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_LtE__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_LtE__1(e_exec):
     """It allows < expressions."""
-    glb = execute('a = (1 <= 3)')
+    glb = e_exec('a = (1 <= 3)')
     assert glb['a'] is True
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_Gt__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Gt__1(e_exec):
     """It allows > expressions."""
-    glb = execute('a = (1 > 3)')
+    glb = e_exec('a = (1 > 3)')
     assert glb['a'] is False
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_GtE__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_GtE__1(e_exec):
     """It allows >= expressions."""
-    glb = execute('a = (1 >= 3)')
+    glb = e_exec('a = (1 >= 3)')
     assert glb['a'] is False
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_Is__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_Is__1(e_exec):
     """It allows `is` expressions."""
-    glb = execute('a = (None is None)')
+    glb = e_exec('a = (None is None)')
     assert glb['a'] is True
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_IsNot__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_IsNot__1(e_exec):
     """It allows `is not` expressions."""
-    glb = execute('a = (2 is not None)')
+    glb = e_exec('a = (2 is not None)')
     assert glb['a'] is True
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_In__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_In__1(e_exec):
     """It allows `in` expressions."""
-    glb = execute('a = (2 in [1, 2, 3])')
+    glb = e_exec('a = (2 in [1, 2, 3])')
     assert glb['a'] is True
 
 
-@pytest.mark.parametrize(*execute)
-def test_transformer__RestrictingNodeTransformer__visit_NotIn__1(execute):
+@pytest.mark.parametrize(*e_exec)
+def test_transformer__RestrictingNodeTransformer__visit_NotIn__1(e_exec):
     """It allows `in` expressions."""
-    glb = execute('a = (2 not in [1, 2, 3])')
+    glb = e_exec('a = (2 not in [1, 2, 3])')
     assert glb['a'] is False


### PR DESCRIPTION
Use more sane names.
Adapt tests to use the new marks more widely.