### PR TITLE
Use buildout on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 python:
     - 2.7
 install:
-    - pip install .
+    - python bootstrap.py
+    - bin/buildout
 script:
-    - python setup.py test -q
+    - bin/test
 notifications:
     email: false


### PR DESCRIPTION
```bash
$ /opt/Python-2.7.13/bin/virtualenv /tmp/RP
New python executable in /tmp/RP/bin/python
Installing setuptools, pip, wheel...done.
$ /tmp/RP/bin/pip install -U setuptools pip
Requirement already up-to-date: setuptools in /tmp/RP/lib/python2.7/site-packages
Requirement already up-to-date: pip in /tmp/RP/lib/python2.7/site-packages
Requirement already up-to-date: packaging>=16.8 in /tmp/RP/lib/python2.7/site-packages (from setuptools)
Requirement already up-to-date: appdirs>=1.4.0 in /tmp/RP/lib/python2.7/site-packages (from setuptools)
Requirement already up-to-date: six>=1.6.0 in /tmp/RP/lib/python2.7/site-packages (from setuptools)
Requirement already up-to-date: pyparsing in /tmp/RP/lib/python2.7/site-packages (from packaging>=16.8->setuptools)
$ /tmp/RP/bin/pip install .
Processing /home/tseaver/projects/Zope/Z2/RestrictedPython
...
Successfully installed RestrictedPython-3.7.dev0
$ /tmp/RP/bin/python setup.py test -q
$ /tmp/RP/bin/python setup.py -q test -q
/tmp/RP/lib/python2.7/site-packages/setuptools/dist.py:333: UserWarning: Normalizing '3.7dev' to '3.7.dev0'
  normalized_version,

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
```

Not good. :(