### PR TITLE
Port eval py

### DIFF
--- a/src/RestrictedPython/Eval.py
+++ b/src/RestrictedPython/Eval.py
@@ -13,8 +13,8 @@
 """Restricted Python Expressions."""
 
 import ast
-from RestrictedPython.RCompile import compile_restricted_eval
 
+from .compile import compile_restricted_eval
 from ._compat import IS_PY2
 
 if IS_PY2:

--- a/src/RestrictedPython/Eval.py
+++ b/src/RestrictedPython/Eval.py
@@ -14,13 +14,16 @@
 
 import ast
 from RestrictedPython.RCompile import compile_restricted_eval
-from string import strip
-from string import translate
 
-import string
+from ._compat import IS_PY2
+
+if IS_PY2:
+    from string import maketrans
+else:
+    maketrans = str.maketrans
 
 
-nltosp = string.maketrans('\r\n', '  ')
+nltosp = maketrans('\r\n', '  ')
 
 default_guarded_getattr = getattr  # No restrictions.
 
@@ -45,9 +48,9 @@ class RestrictionCapableEval(object):
 
           expr -- a string containing the expression to be evaluated.
         """
-        expr = strip(expr)
+        expr = expr.strip()
         self.__name__ = expr
-        expr = translate(expr, nltosp)
+        expr = expr.translate(nltosp)
         self.expr = expr
         self.prepUnrestrictedCode()  # Catch syntax errors.
 

--- a/src/RestrictedPython/Eval.py
+++ b/src/RestrictedPython/Eval.py
@@ -30,9 +30,6 @@ def default_guarded_getitem(ob, index):
     return ob[index]
 
 
-PROFILE = 0
-
-
 class RestrictionCapableEval(object):
     """A base class for restricted code."""
 
@@ -56,15 +53,7 @@ class RestrictionCapableEval(object):
 
     def prepRestrictedCode(self):
         if self.rcode is None:
-            if PROFILE:
-                from time import clock
-                start = clock()
-            co, err, warn, used = compile_restricted_eval(
-                self.expr, '<string>')
-            if PROFILE:
-                end = clock()
-                print('prepRestrictedCode: %d ms for %s' % (
-                    (end - start) * 1000, repr(self.expr)))
+            co, err, warn, used = compile_restricted_eval(self.expr, '<string>')
             if err:
                 raise SyntaxError(err[0])
             self.used = tuple(used.keys())

--- a/src/RestrictedPython/tests/testRestrictions.py
+++ b/src/RestrictedPython/tests/testRestrictions.py
@@ -6,7 +6,6 @@
 # here instead.
 
 from RestrictedPython import PrintCollector
-from RestrictedPython.Eval import RestrictionCapableEval
 from RestrictedPython.RCompile import compile_restricted
 from RestrictedPython.RCompile import RFunction
 from RestrictedPython.RCompile import RModule
@@ -306,17 +305,6 @@ class RestrictionTests(unittest.TestCase):
     def test_NestedScopes1(self):
         res = self.execFunc('nested_scopes_1')
         self.assertEqual(res, 2)
-
-    def test_UnrestrictedEval(self):
-        expr = RestrictionCapableEval("{'a':[m.pop()]}['a'] + [m[0]]")
-        v = [12, 34]
-        expect = v[:]
-        expect.reverse()
-        res = expr.eval({'m': v})
-        self.assertEqual(res, expect)
-        v = [12, 34]
-        res = expr(m=v)
-        self.assertEqual(res, expect)
 
     def test_StackSize(self):
         for k, rfunc in rmodule.items():

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -147,3 +147,11 @@ def test_compile__compile_restricted_eval__1(c_eval):
 def test_compile__compile_restricted_eval__2(e_eval):
     """It compiles code as an Expression."""
     assert e_eval('4 * 6') == 24
+
+
+@pytest.mark.parametrize(*c_eval)
+def test_compile__compile_restricted_eval__used_names(c_eval):
+    result = c_eval("a + b + func(x)")
+    assert result.errors == ()
+    assert result.warnings == []
+    assert result.used_names == {'a': True, 'b': True, 'x': True, 'func': True}

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,39 @@
+import pytest
+from RestrictedPython.Eval import RestrictionCapableEval
+
+exp = """
+    {'a':[m.pop()]}['a'] \
+        + [m[0]]
+"""
+
+def test_init():
+    ob = RestrictionCapableEval(exp)
+
+    assert ob.expr == "{'a':[m.pop()]}['a']         + [m[0]]"
+    assert ob.used == ('m', )
+    assert ob.ucode is not None
+    assert ob.rcode is None
+
+
+def test_init_with_syntax_error():
+    with pytest.raises(SyntaxError):
+        RestrictionCapableEval("if:")
+
+
+def test_prepRestrictedCode():
+    ob = RestrictionCapableEval(exp)
+    ob.prepRestrictedCode()
+    assert ob.used == ('m', )
+    assert ob.rcode is not None
+
+
+def test_call():
+    ob = RestrictionCapableEval(exp)
+    ret = ob(m=[1, 2])
+    assert ret == [2, 1]
+
+
+def test_eval():
+    ob = RestrictionCapableEval(exp)
+    ret = ob.eval({'m': [1, 2]})
+    assert ret == [2, 1]

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,10 +1,13 @@
-import pytest
 from RestrictedPython.Eval import RestrictionCapableEval
+
+import pytest
+
 
 exp = """
     {'a':[m.pop()]}['a'] \
         + [m[0]]
 """
+
 
 def test_init():
     ob = RestrictionCapableEval(exp)

--- a/tests/transformer/test_transformer.py
+++ b/tests/transformer/test_transformer.py
@@ -62,11 +62,7 @@ def test_transformer__RestrictingNodeTransformer__visit_Call__1(c_exec):
     loc = {}
     exec(result.code, {}, loc)
     assert loc['a'] == 3
-    if c_exec is RestrictedPython.compile.compile_restricted_exec:
-        # The new version not yet supports `used_names`:
-        assert result.used_names == {}
-    else:
-        assert result.used_names == {'max': True}
+    assert result.used_names == {'max': True}
 
 
 YIELD = """\


### PR DESCRIPTION
This ports `Eval.py` to python3 by using the methods from `compile.py`.

As a side effect I brought back support for `used_names` in  `RestrictingNodeTransformer`.
I know nowadays `used_names` could have been a `set()`, but I didn't dare to change the API.
Since `used_names` is used by other code outside of RestrictedPython.