### PR TITLE
Allow `sets` again.

### DIFF
--- a/src/RestrictedPython/Utilities.py
+++ b/src/RestrictedPython/Utilities.py
@@ -36,6 +36,12 @@ utility_builtins['set'] = set
 utility_builtins['frozenset'] = frozenset
 
 try:
+    import sets
+    utility_builtins['sets'] = sets
+except ImportError:
+    pass
+
+try:
     import DateTime
     utility_builtins['DateTime'] = DateTime.DateTime
 except ImportError:

--- a/tests/builtins/test_utilities.py
+++ b/tests/builtins/test_utilities.py
@@ -1,3 +1,6 @@
+from RestrictedPython._compat import IS_PY3
+import pytest
+
 
 def test_string_in_utility_builtins():
     import string
@@ -26,6 +29,14 @@ def test_random_in_utility_builtins():
 def test_set_in_utility_builtins():
     from RestrictedPython.Utilities import utility_builtins
     assert utility_builtins['set'] is set
+
+
+@pytest.mark.skipif(IS_PY3,
+                    reason='Python 3 has no longer includes the sets module.')
+def test_sets_in_utility_builtins():
+    from RestrictedPython.Utilities import utility_builtins
+    import sets
+    assert utility_builtins['sets'] is sets
 
 
 def test_frozenset_in_utility_builtins():


### PR DESCRIPTION
This is for backwards compatibility with existing code which might use sets.