### PR TITLE
Do not attempt to import builtins on Python 2.7

### DIFF
--- a/src/RestrictedPython/Guards.py
+++ b/src/RestrictedPython/Guards.py
@@ -18,10 +18,12 @@
 from ._compat import IS_PY2
 
 
-try:
-    import builtins
-except ImportError:
+if IS_PY2:
     import __builtin__ as builtins
+else:
+    # Do not attempt to use this package on Python2.7 as there
+    # might be backports for this package such as future.
+    import builtins
 
 safe_builtins = {}
 


### PR DESCRIPTION
There's a backport this package part of `future` which provides other
builtins (and breaks tests if it's installed).