### PR TITLE
Adjust import code conventions in setup.cfg[isort] and applied

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,4 +12,7 @@ omit =
     #src/RestrictedPython/tests/*.py
 
 [report]
-precision = 3
+precision = 2
+
+[html]
+directory = reports/coverage

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ pyvenv.cfg
 /eggs
 /fake-eggs
 /htmlcov
-/report-*.html
+/reports
 /include
 /lib
 /share

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,49 @@
 RestrictedPython
 ================
 
-RestrictedPython is a defined subset of the Python language which allows to provide a program input into a trusted environment.
+RestrictedPython is a tool that helps to define a subset of the Python language which allows to provide a program input into a trusted environment.
+RestrictedPython is not a sandbox system or a secured environment, but it helps to define a trusted environment and execute untrusted code inside of it.
 
 For full documentation please see  http://restrictedpython.readthedocs.io/ or the local ``docs/index``.
+
+Example
+=======
+
+To give a basic understanding what RestrictedPython does here two examples:
+
+An unproblematic code example
+-----------------------------
+
+Python allows you to execute a large set of commands.
+This would not harm any system.
+
+    >>> from RestrictedPython import compile_restricted
+    >>> from RestrictedPython import safe_builtins
+    >>>
+    >>> source_code = """
+    ... def example():
+    ...     return 'Hello World!'
+    ... """
+    >>>
+    >>> locals = {}
+    >>> byte_code = compile_restricted(source_code, '<inline>', 'exec')
+    >>> exec(byte_code, safe_builtins, locals)
+    >>>
+    >>> locals['example']()
+    'Hello World!'
+
+Problematic code example
+------------------------
+
+This example directly executed in Python could harm your system.
+
+  >>> from RestrictedPython import compile_restricted
+  >>> from RestrictedPython import safe_builtins
+  >>>
+  >>> source_code = """
+  ... import os
+  ...
+  ... os.listdir('/')
+  ... """
+  >>> byte_code = compile_restricted(source_code, '<inline>', 'exec')
+  >>> # exec(byte_code, safe_builtins, {})

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,10 @@ isort_ignore =
 force_alphabetical_sort = True
 force_single_line = True
 
-sections=FUTURE,STDLIB,ZOPE,FIRSTPARTY,THIRDPARTY,LOCALFOLDER
+sections = FUTURE,STDLIB,ZOPE,FIRSTPARTY,THIRDPARTY,LOCALFOLDER
 
+known_future_library = future,__future__
+known_standard_library = os,sys,types
 known_zope = zope,Products,zc,z3c
 
 import_heading_stdlib = Standard Library Imports

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,21 +35,25 @@ force_single_line = True
 force_to_top = False
 from_first = True
 
-sections = FUTURE,STDLIB,COMPATLIB,FIRSTPARTY,THIRDPARTY,ZOPE,LOCALFOLDER
+sections = FUTURE,STDLIB,COMPATLIBS,TESTLIBS,FIRSTPARTY,THIRDPARTY,ZOPE,LOCALFOLDER,TESTINTERNALS
 
-known_compatlib = six
+known_compatlibs = six
+known_testlibs = pytest
 known_firstparty =
 known_thirdparty =
 known_zope = zope,Products,zc,z3c,ExtensionClass,Acquisition,Persistence,RestrictedPython
 known_localfolder = RestrictedPython
+known_testinternals = tests
 
-import_heading_future_library = Future Imports
-import_heading_stdlib = Standard Library Imports
-import_heading_compatlib = Python 2 / 3 compatibility helper libraries
+import_heading_future_library = Future imports
+import_heading_stdlib = Standard library imports
+import_heading_compatlibs = Python 2 / 3 compatibility helper libraries
+import_heading_testlibs = Test framework imports
 import_heading_firstparty =
 import_heading_thirdparty =
-import_heading_zope = Zope Imports
+import_heading_zope = Zope imports
 import_heading_localfolder = RestrictedPython internal imports
+import_heading_testinternals = Test internals (fixures and helpers)
 
 line_length = 200
 lines_after_imports = 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,14 @@ isort_ignore =
 [isort]
 force_alphabetical_sort = True
 force_single_line = True
+
+sections=FUTURE,STDLIB,ZOPE,FIRSTPARTY,THIRDPARTY,LOCALFOLDER
+
+known_zope = zope,Products,zc,z3c
+
+import_heading_stdlib = Standard Library Imports
+import_heading_firstparty = Zope Imports
+
 lines_after_imports = 2
 line_length = 200
 skip =

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,20 +30,30 @@ isort_ignore =
 
 
 [isort]
-force_alphabetical_sort = True
+force_alphabetical_sort = False
 force_single_line = True
+force_to_top = False
+from_first = True
 
-sections = FUTURE,STDLIB,ZOPE,FIRSTPARTY,THIRDPARTY,LOCALFOLDER
+sections = FUTURE,STDLIB,COMPATLIB,FIRSTPARTY,THIRDPARTY,ZOPE,LOCALFOLDER
 
-known_future_library = future,__future__
-known_standard_library = os,sys,types
-known_zope = zope,Products,zc,z3c
+known_compatlib = six
+known_firstparty =
+known_thirdparty =
+known_zope = zope,Products,zc,z3c,ExtensionClass,Acquisition,Persistence,RestrictedPython
+known_localfolder = RestrictedPython
 
+import_heading_future_library = Future Imports
 import_heading_stdlib = Standard Library Imports
-import_heading_firstparty = Zope Imports
+import_heading_compatlib = Python 2 / 3 compatibility helper libraries
+import_heading_firstparty =
+import_heading_thirdparty =
+import_heading_zope = Zope Imports
+import_heading_localfolder = RestrictedPython internal imports
 
-lines_after_imports = 2
 line_length = 200
+lines_after_imports = 2
+
 skip =
     bootstrap.py
 not_skip =

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ not_skip =
 exclude =
     bootstrap.py,
     src/RestrictedPython/tests,
-    src/RestrictedPython/SelectCompiler.py,
+    #src/RestrictedPython/SelectCompiler.py,
 
 ignore =
     N801,

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,9 @@ setup(name='RestrictedPython',
       version='4.0a2.dev0',
       url='http://pypi.python.org/pypi/RestrictedPython',
       license='ZPL 2.1',
-      description='RestrictedPython provides a restricted execution '
-                  'environment for Python, e.g. for running untrusted code.',
+      description='RestrictedPython is a defined subset of the Python language'
+                  ' which allows to provide a program input into a trusted'
+                  ' environment.',
       long_description=(read('README.rst') + '\n' +
                         read('docs', 'CHANGES.rst')),
       classifiers=[

--- a/src/RestrictedPython/Eval.py
+++ b/src/RestrictedPython/Eval.py
@@ -13,12 +13,11 @@
 """Restricted Python Expressions."""
 
 # Standard library imports
-# Standard Library Imports
 import ast
 
 # RestrictedPython internal imports
-from ._compat import IS_PY2
-from .compile import compile_restricted_eval
+from RestrictedPython._compat import IS_PY2
+from RestrictedPython.compile import compile_restricted_eval
 
 
 if IS_PY2:

--- a/src/RestrictedPython/Eval.py
+++ b/src/RestrictedPython/Eval.py
@@ -12,10 +12,13 @@
 ##############################################################################
 """Restricted Python Expressions."""
 
+# Standard library imports
+# Standard Library Imports
+import ast
+
+# RestrictedPython internal imports
 from ._compat import IS_PY2
 from .compile import compile_restricted_eval
-
-import ast
 
 
 if IS_PY2:

--- a/src/RestrictedPython/Guards.py
+++ b/src/RestrictedPython/Guards.py
@@ -16,7 +16,7 @@
 # DocumentTemplate.DT_UTil contains a few.
 
 # RestrictedPython internal imports
-from ._compat import IS_PY2
+from RestrictedPython._compat import IS_PY2
 
 
 if IS_PY2:

--- a/src/RestrictedPython/Guards.py
+++ b/src/RestrictedPython/Guards.py
@@ -15,6 +15,7 @@
 # AccessControl.ZopeGuards contains a large set of wrappers for builtins.
 # DocumentTemplate.DT_UTil contains a few.
 
+# RestrictedPython internal imports
 from ._compat import IS_PY2
 
 

--- a/src/RestrictedPython/MutatingWalker.py
+++ b/src/RestrictedPython/MutatingWalker.py
@@ -11,8 +11,9 @@
 #
 ##############################################################################
 
+# Standard library imports
+# Standard Library Imports
 from compiler import ast
-
 import warnings
 
 

--- a/src/RestrictedPython/MutatingWalker.py
+++ b/src/RestrictedPython/MutatingWalker.py
@@ -12,7 +12,6 @@
 ##############################################################################
 
 # Standard library imports
-# Standard Library Imports
 from compiler import ast
 import warnings
 

--- a/src/RestrictedPython/PrintCollector.py
+++ b/src/RestrictedPython/PrintCollector.py
@@ -10,6 +10,7 @@
 # FOR A PARTICULAR PURPOSE
 #
 ##############################################################################
+
 from __future__ import print_function
 
 

--- a/src/RestrictedPython/RCompile.py
+++ b/src/RestrictedPython/RCompile.py
@@ -14,7 +14,8 @@
 Python standard library.
 """
 
-from compile import CompileResult
+# Standard library imports
+# Standard Library Imports
 from compiler import ast
 from compiler import misc
 from compiler import parse
@@ -22,15 +23,16 @@ from compiler import pycodegen
 from compiler import syntax
 from compiler.pycodegen import AbstractCompileMode
 from compiler.pycodegen import Expression
-from compiler.pycodegen import findOp
 from compiler.pycodegen import FunctionCodeGenerator  # noqa
 from compiler.pycodegen import Interactive
 from compiler.pycodegen import Module
 from compiler.pycodegen import ModuleCodeGenerator
-from RestrictionMutator import RestrictionMutator
-
-import MutatingWalker
+from compiler.pycodegen import findOp
 import warnings
+
+from compile import CompileResult
+from RestrictionMutator import RestrictionMutator
+import MutatingWalker
 
 
 warnings.warn(

--- a/src/RestrictedPython/RCompile.py
+++ b/src/RestrictedPython/RCompile.py
@@ -15,7 +15,6 @@ Python standard library.
 """
 
 # Standard library imports
-# Standard Library Imports
 from compiler import ast
 from compiler import misc
 from compiler import parse
@@ -30,9 +29,10 @@ from compiler.pycodegen import ModuleCodeGenerator
 from compiler.pycodegen import findOp
 import warnings
 
-from compile import CompileResult
-from RestrictionMutator import RestrictionMutator
-import MutatingWalker
+# RestrictedPython internal imports
+from RestrictedPython.compile import CompileResult
+from RestrictedPython.MutatingWalker import walk
+from RestrictedPython.RestrictionMutator import RestrictionMutator
 
 
 warnings.warn(
@@ -76,7 +76,7 @@ class RestrictedCompileMode(AbstractCompileMode):
 
     def _get_tree(self):
         tree = self.parse()
-        MutatingWalker.walk(tree, self.rm)
+        walk(tree, self.rm)
         if self.rm.errors:
             raise SyntaxError(self.rm.errors[0])
         misc.set_filename(self.filename, tree)

--- a/src/RestrictedPython/README.rst
+++ b/src/RestrictedPython/README.rst
@@ -1,5 +1,7 @@
 .. contents::
 
+.. TODO:: move this documentation into docs
+
 Overview
 ========
 

--- a/src/RestrictedPython/RestrictionMutator.py
+++ b/src/RestrictedPython/RestrictionMutator.py
@@ -17,12 +17,13 @@ compiler.transformer.Transformer, restricting and enhancing the
 code in various ways before sending it to pycodegen.
 """
 
+# Standard library imports
+# Standard Library Imports
 from compiler import ast
 from compiler.consts import OP_APPLY
 from compiler.consts import OP_ASSIGN
 from compiler.consts import OP_DELETE
 from compiler.transformer import parse
-
 import warnings
 
 

--- a/src/RestrictedPython/RestrictionMutator.py
+++ b/src/RestrictedPython/RestrictionMutator.py
@@ -18,7 +18,6 @@ code in various ways before sending it to pycodegen.
 """
 
 # Standard library imports
-# Standard Library Imports
 from compiler import ast
 from compiler.consts import OP_APPLY
 from compiler.consts import OP_ASSIGN

--- a/src/RestrictedPython/SelectCompiler.py
+++ b/src/RestrictedPython/SelectCompiler.py
@@ -13,19 +13,21 @@
 """Compiler selector.
 """
 
+# Standard library imports
+# Standard Library Imports
 from compiler import ast
 from compiler.consts import OP_APPLY
 from compiler.consts import OP_ASSIGN
 from compiler.consts import OP_DELETE
 from compiler.transformer import parse
+# Use the compiler from the standard library.
+import compiler
+import warnings
+
 from RCompile import compile_restricted
 from RCompile import compile_restricted_eval
 from RCompile import compile_restricted_exec
 from RCompile import compile_restricted_function
-
-# Use the compiler from the standard library.
-import compiler
-import warnings
 
 
 warnings.warn(

--- a/src/RestrictedPython/SelectCompiler.py
+++ b/src/RestrictedPython/SelectCompiler.py
@@ -13,14 +13,15 @@
 """Compiler selector.
 """
 
+# flake8: NOQA: 401
+# isort: skip
+
 # Standard library imports
-# Standard Library Imports
 from compiler import ast
 from compiler.consts import OP_APPLY
 from compiler.consts import OP_ASSIGN
 from compiler.consts import OP_DELETE
 from compiler.transformer import parse
-# Use the compiler from the standard library.
 import compiler
 import warnings
 

--- a/src/RestrictedPython/Utilities.py
+++ b/src/RestrictedPython/Utilities.py
@@ -11,6 +11,8 @@
 #
 ##############################################################################
 
+# Standard library imports
+# Standard Library Imports
 import math
 import random
 import string

--- a/src/RestrictedPython/Utilities.py
+++ b/src/RestrictedPython/Utilities.py
@@ -12,7 +12,6 @@
 ##############################################################################
 
 # Standard library imports
-# Standard Library Imports
 import math
 import random
 import string

--- a/src/RestrictedPython/__init__.py
+++ b/src/RestrictedPython/__init__.py
@@ -13,9 +13,10 @@
 """RestrictedPython package."""
 
 # flake8: NOQA: E401
+# isort: skip
 
 # This is a file to define public API in the base namespace of the package.
-# use: isor:skip to supress all isort related warnings / errors,
+# use: isort:skip to supress all isort related warnings / errors,
 # as this file should be logically grouped imports
 
 
@@ -25,26 +26,22 @@
 # from RestrictedPython.RCompile import compile_restricted_exec
 # from RestrictedPython.RCompile import compile_restricted_function
 
+# RestrictedPython internal imports
 # new API Style
 # compile_restricted methods:
-from RestrictedPython.compile import compile_restricted  # isort:skip
-from RestrictedPython.compile import compile_restricted_eval  # isort:skip
-from RestrictedPython.compile import compile_restricted_exec  # isort:skip
-from RestrictedPython.compile import compile_restricted_function  # isort:skip
-from RestrictedPython.compile import compile_restricted_single  # isort:skip
-
-# predefined builtins
-from RestrictedPython.Guards import safe_builtins  # isort:skip
-from RestrictedPython.Limits import limited_builtins  # isort:skip
-from RestrictedPython.Utilities import utility_builtins  # isort:skip
-
-# Helper Methods
-from RestrictedPython.PrintCollector import PrintCollector  # isort:skip
-from RestrictedPython.compile import CompileResult  # isort:skip
-
-# Policy
-from RestrictedPython.transformer import RestrictingNodeTransformer  # isort:skip
-
-# RestrictedPython internal imports
+from RestrictedPython.compile import CompileResult
+from RestrictedPython.compile import compile_restricted
+from RestrictedPython.compile import compile_restricted_eval
+from RestrictedPython.compile import compile_restricted_exec
+from RestrictedPython.compile import compile_restricted_function
+from RestrictedPython.compile import compile_restricted_single
 #
 from RestrictedPython.Eval import RestrictionCapableEval
+# predefined builtins
+from RestrictedPython.Guards import safe_builtins
+from RestrictedPython.Limits import limited_builtins
+# Helper Methods
+from RestrictedPython.PrintCollector import PrintCollector
+# Policy
+from RestrictedPython.transformer import RestrictingNodeTransformer
+from RestrictedPython.Utilities import utility_builtins

--- a/src/RestrictedPython/__init__.py
+++ b/src/RestrictedPython/__init__.py
@@ -45,5 +45,6 @@ from RestrictedPython.compile import CompileResult  # isort:skip
 # Policy
 from RestrictedPython.transformer import RestrictingNodeTransformer  # isort:skip
 
+# RestrictedPython internal imports
 #
 from RestrictedPython.Eval import RestrictionCapableEval

--- a/src/RestrictedPython/_compat.py
+++ b/src/RestrictedPython/_compat.py
@@ -1,3 +1,5 @@
+
+# Standard library imports
 import sys
 
 

--- a/src/RestrictedPython/compile.py
+++ b/src/RestrictedPython/compile.py
@@ -1,9 +1,12 @@
-from collections import namedtuple
-from RestrictedPython._compat import IS_PY2
-from RestrictedPython.transformer import RestrictingNodeTransformer
 
+# Standard library imports
+from collections import namedtuple
 import ast
 import warnings
+
+# RestrictedPython internal imports
+from RestrictedPython._compat import IS_PY2
+from RestrictedPython.transformer import RestrictingNodeTransformer
 
 
 CompileResult = namedtuple(

--- a/src/RestrictedPython/tests/restricted_module.py
+++ b/src/RestrictedPython/tests/restricted_module.py
@@ -1,3 +1,5 @@
+
+# Standard library imports
 import sys
 
 

--- a/src/RestrictedPython/tests/testCompile.py
+++ b/src/RestrictedPython/tests/testCompile.py
@@ -12,10 +12,13 @@
 #
 ##############################################################################
 
-from RestrictedPython.RCompile import niceParse
-
+# Standard library imports
+# Standard Library Imports
 import compiler.ast
 import unittest
+
+# RestrictedPython internal imports
+from RestrictedPython.RCompile import niceParse
 
 
 class CompileTests(unittest.TestCase):

--- a/src/RestrictedPython/tests/testREADME.py
+++ b/src/RestrictedPython/tests/testREADME.py
@@ -13,8 +13,9 @@
 ##############################################################################
 """Run tests in README.txt
 """
+# Standard library imports
+# Standard Library Imports
 from doctest import DocFileSuite
-
 import unittest
 
 

--- a/src/RestrictedPython/tests/testRestrictions.py
+++ b/src/RestrictedPython/tests/testRestrictions.py
@@ -5,17 +5,20 @@
 # AccessControl, so we need to define throwaway wrapper implementations
 # here instead.
 
-from RestrictedPython import PrintCollector
-from RestrictedPython.RCompile import compile_restricted
-from RestrictedPython.RCompile import RFunction
-from RestrictedPython.RCompile import RModule
-from RestrictedPython.tests import restricted_module
-from RestrictedPython.tests import verify
-
+# Standard library imports
+# Standard Library Imports
 import os
 import re
 import sys
 import unittest
+
+# RestrictedPython internal imports
+from RestrictedPython import PrintCollector
+from RestrictedPython.RCompile import RFunction
+from RestrictedPython.RCompile import RModule
+from RestrictedPython.RCompile import compile_restricted
+from RestrictedPython.tests import restricted_module
+from RestrictedPython.tests import verify
 
 
 try:

--- a/src/RestrictedPython/tests/verify.py
+++ b/src/RestrictedPython/tests/verify.py
@@ -21,6 +21,8 @@ all attribute access is performed via the _getattr_() checker
 function.
 """
 
+# Standard library imports
+# Standard Library Imports
 import dis
 import types
 import warnings

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -17,13 +17,11 @@ uses Python standard library ast module and its containing classes to transform
 the parsed python code to create a modified AST for a byte code generation.
 """
 
-# This package should follow the Plone Sytleguide for Python,
+# This package should follow the Plone Styleguide for Python,
 # which differ from PEP8:
 # http://docs.plone.org/develop/styleguide/python.html
 
-
 # Standard library imports
-# Standard Library Imports
 import ast
 import contextlib
 import textwrap

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -22,14 +22,17 @@ the parsed python code to create a modified AST for a byte code generation.
 # http://docs.plone.org/develop/styleguide/python.html
 
 
+# Standard library imports
+# Standard Library Imports
+import ast
+import contextlib
+import textwrap
+
+# RestrictedPython internal imports
 from ._compat import IS_PY2
 from ._compat import IS_PY3
 from ._compat import IS_PY34_OR_GREATER
 from ._compat import IS_PY35_OR_GREATER
-
-import ast
-import contextlib
-import textwrap
 
 
 # For AugAssign the operator must be converted to a string.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
+# RestrictedPython internal imports
 from RestrictedPython._compat import IS_PY2
-
 import RestrictedPython
 
 

--- a/tests/builtins/test_limits.py
+++ b/tests/builtins/test_limits.py
@@ -1,8 +1,10 @@
+# Test framework imports
+import pytest
+
+# RestrictedPython internal imports
 from RestrictedPython.Limits import limited_list
 from RestrictedPython.Limits import limited_range
 from RestrictedPython.Limits import limited_tuple
-
-import pytest
 
 
 def test_limited_range_length_1():

--- a/tests/builtins/test_utilities.py
+++ b/tests/builtins/test_utilities.py
@@ -1,6 +1,8 @@
-from RestrictedPython._compat import IS_PY3
-
+# Test framework imports
 import pytest
+
+# RestrictedPython internal imports
+from RestrictedPython._compat import IS_PY3
 
 
 def test_string_in_utility_builtins():

--- a/tests/test_Guards.py
+++ b/tests/test_Guards.py
@@ -1,8 +1,12 @@
+# Test framework imports
+import pytest
+
+# RestrictedPython internal imports
 from RestrictedPython.Guards import safe_builtins
+
+# Test internals (fixures and helpers)
 from tests import e_eval
 from tests import e_exec
-
-import pytest
 
 
 @pytest.mark.parametrize(*e_eval)

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,15 +1,22 @@
-from RestrictedPython import compile_restricted
+
+# Standard library imports
+import types
+
+# Test framework imports
+import pytest
+
+# RestrictedPython internal imports
 from RestrictedPython import CompileResult
+from RestrictedPython import compile_restricted
 from RestrictedPython._compat import IS_PY2
 from RestrictedPython._compat import IS_PY3
+import RestrictedPython.compile
+
+# Test internals (fixures and helpers)
 from tests import c_eval
 from tests import c_exec
 from tests import c_single
 from tests import e_eval
-
-import pytest
-import RestrictedPython.compile
-import types
 
 
 def test_compile__compile_restricted_invalid_code_input():

--- a/tests/test_compile_restricted_function.py
+++ b/tests/test_compile_restricted_function.py
@@ -1,9 +1,16 @@
-from RestrictedPython import PrintCollector
-from RestrictedPython import safe_builtins
-from tests import c_function
+
+# Standard library imports
 from types import FunctionType
 
+# Test framework imports
 import pytest
+
+# RestrictedPython internal imports
+from RestrictedPython import PrintCollector
+from RestrictedPython import safe_builtins
+
+# Test internals (fixures and helpers)
+from tests import c_function
 
 
 @pytest.mark.parametrize(*c_function)

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,6 +1,8 @@
-from RestrictedPython.Eval import RestrictionCapableEval
-
+# Test framework imports
 import pytest
+
+# RestrictedPython internal imports
+from RestrictedPython.Eval import RestrictionCapableEval
 
 
 exp = """

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,31 @@
+"""
+Tests about imports
+"""
+
+# Test framework imports
+import pytest
+
+# Test internals (fixures and helpers)
+from tests import c_exec
+from tests import e_exec
+
+
+OS_IMPORT_EXAMPLE = """
+import os
+
+os.listdir('/')
+"""
+
+
+@pytest.mark.parametrize(*c_exec)
+@pytest.mark.parametrize(*e_exec)
+def test_os_import(c_exec, e_exec):
+    """Test that import should not work out of the box.
+    TODO: Why does this work.
+    """
+    result = c_exec(OS_IMPORT_EXAMPLE)
+    assert result.code is not None
+    assert result.errors == ()
+
+    # with pytest.raises(NameError):
+    #    e_exec(OS_IMPORT_EXAMPLE)

--- a/tests/test_print_function.py
+++ b/tests/test_print_function.py
@@ -1,5 +1,5 @@
+# RestrictedPython internal imports
 from RestrictedPython.PrintCollector import PrintCollector
-
 import RestrictedPython
 
 

--- a/tests/test_print_stmt.py
+++ b/tests/test_print_stmt.py
@@ -1,9 +1,13 @@
+# Test framework imports
+import pytest
+
+# RestrictedPython internal imports
 from RestrictedPython._compat import IS_PY3
 from RestrictedPython.PrintCollector import PrintCollector
-from tests import c_exec
-
-import pytest
 import RestrictedPython
+
+# Test internals (fixures and helpers)
+from tests import c_exec
 
 
 pytestmark = pytest.mark.skipif(

--- a/tests/transformer/operators/test_arithmetic_operators.py
+++ b/tests/transformer/operators/test_arithmetic_operators.py
@@ -1,8 +1,12 @@
+# Test framework imports
+import pytest
+
+# RestrictedPython internal imports
 from RestrictedPython._compat import IS_PY35_OR_GREATER
+
+# Test internals (fixures and helpers)
 from tests import c_eval
 from tests import e_eval
-
-import pytest
 
 
 # Arithmetic Operators

--- a/tests/transformer/operators/test_bit_wise_operators.py
+++ b/tests/transformer/operators/test_bit_wise_operators.py
@@ -1,6 +1,8 @@
-from tests import e_eval
-
+# Test framework imports
 import pytest
+
+# Test internals (fixures and helpers)
+from tests import e_eval
 
 
 @pytest.mark.parametrize(*e_eval)

--- a/tests/transformer/operators/test_bool_operators.py
+++ b/tests/transformer/operators/test_bool_operators.py
@@ -1,6 +1,8 @@
-from tests import e_eval
-
+# Test framework imports
 import pytest
+
+# Test internals (fixures and helpers)
+from tests import e_eval
 
 
 @pytest.mark.parametrize(*e_eval)

--- a/tests/transformer/operators/test_comparison_operators.py
+++ b/tests/transformer/operators/test_comparison_operators.py
@@ -1,6 +1,8 @@
-from tests import e_eval
-
+# Test framework imports
 import pytest
+
+# Test internals (fixures and helpers)
+from tests import e_eval
 
 
 @pytest.mark.parametrize(*e_eval)

--- a/tests/transformer/operators/test_identity_operators.py
+++ b/tests/transformer/operators/test_identity_operators.py
@@ -1,6 +1,8 @@
-from tests import e_eval
-
+# Test framework imports
 import pytest
+
+# Test internals (fixures and helpers)
+from tests import e_eval
 
 
 @pytest.mark.parametrize(*e_eval)

--- a/tests/transformer/operators/test_logical_operators.py
+++ b/tests/transformer/operators/test_logical_operators.py
@@ -1,6 +1,8 @@
-from tests import e_eval
-
+# Test framework imports
 import pytest
+
+# Test internals (fixures and helpers)
+from tests import e_eval
 
 
 @pytest.mark.parametrize(*e_eval)

--- a/tests/transformer/operators/test_unary_operators.py
+++ b/tests/transformer/operators/test_unary_operators.py
@@ -1,6 +1,8 @@
-from tests import e_eval
-
+# Test framework imports
 import pytest
+
+# Test internals (fixures and helpers)
+from tests import e_eval
 
 
 @pytest.mark.parametrize(*e_eval)

--- a/tests/transformer/test_async.py
+++ b/tests/transformer/test_async.py
@@ -1,9 +1,13 @@
+# Test framework imports
+import pytest
+
+# RestrictedPython internal imports
 from RestrictedPython import compile_restricted_exec
 from RestrictedPython._compat import IS_PY35_OR_GREATER
 from RestrictedPython.transformer import RestrictingNodeTransformer
-from tests import c_exec
 
-import pytest
+# Test internals (fixures and helpers)
+from tests import c_exec
 
 
 pytestmark = pytest.mark.skipif(

--- a/tests/transformer/test_base_types.py
+++ b/tests/transformer/test_base_types.py
@@ -1,8 +1,12 @@
+# Test framework imports
+import pytest
+
+# RestrictedPython internal imports
 from RestrictedPython._compat import IS_PY2
+
+# Test internals (fixures and helpers)
 from tests import c_exec
 from tests import e_eval
-
-import pytest
 
 
 @pytest.mark.parametrize(*e_eval)

--- a/tests/transformer/test_global_local.py
+++ b/tests/transformer/test_global_local.py
@@ -1,8 +1,12 @@
+# Test framework imports
+import pytest
+
+# RestrictedPython internal imports
 from RestrictedPython._compat import IS_PY3
+
+# Test internals (fixures and helpers)
 from tests import c_exec
 from tests import e_exec
-
-import pytest
 
 
 GLOBAL_EXAMPLE = """

--- a/tests/transformer/test_slice.py
+++ b/tests/transformer/test_slice.py
@@ -1,7 +1,11 @@
+# Standard library imports
 from operator import getitem
-from tests import e_eval
 
+# Test framework imports
 import pytest
+
+# Test internals (fixures and helpers)
+from tests import e_eval
 
 
 @pytest.mark.parametrize(*e_eval)

--- a/tests/transformer/test_subscript.py
+++ b/tests/transformer/test_subscript.py
@@ -1,6 +1,8 @@
-from tests import e_exec
-
+# Test framework imports
 import pytest
+
+# Test internals (fixures and helpers)
+from tests import e_exec
 
 
 SIMPLE_SUBSCRIPTS = """

--- a/tests/transformer/test_transformer.py
+++ b/tests/transformer/test_transformer.py
@@ -1,18 +1,24 @@
+# Standard library imports
+import ast
+import contextlib
+import types
+
+# Test framework imports
+import pytest
+
+# RestrictedPython internal imports
 from RestrictedPython import RestrictingNodeTransformer
 from RestrictedPython._compat import IS_PY2
 from RestrictedPython._compat import IS_PY3
 from RestrictedPython.Guards import guarded_iter_unpack_sequence
 from RestrictedPython.Guards import guarded_unpack_sequence
 from RestrictedPython.Guards import safe_builtins
+import RestrictedPython
+
+# Test internals (fixures and helpers)
 from tests import c_exec
 from tests import e_eval
 from tests import e_exec
-
-import ast
-import contextlib
-import pytest
-import RestrictedPython
-import types
 
 
 def test_transformer__RestrictingNodeTransformer__generic_visit__1():

--- a/tests/transformer/test_yield.py
+++ b/tests/transformer/test_yield.py
@@ -1,7 +1,11 @@
-from RestrictedPython._compat import IS_PY3
-from tests import c_exec
-
+# Test framework imports
 import pytest
+
+# RestrictedPython internal imports
+from RestrictedPython._compat import IS_PY3
+
+# Test internals (fixures and helpers)
+from tests import c_exec
 
 
 YIELD_EXAMPLE = """\

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    flake8,
     coverage-clean,
     py27,
     py27-datetime,
@@ -12,6 +11,7 @@ envlist =
     pypy,
     docs,
     isort,
+    flake8,
     coverage-report,
 skip_missing_interpreters = False
 
@@ -21,8 +21,8 @@ extras =
     develop
     test
 commands =
-    pytest --cov=src --cov-report=xml --html=report-{envname}.html --self-contained-html {posargs}
-    pytest --doctest-modules src/RestrictedPython/compile.py {posargs}
+    pytest --cov=src --cov-report=xml --html=reports/pytest/report-{envname}.html --self-contained-html {posargs}
+    pytest --doctest-modules src/RestrictedPython/compile.py README.rst {posargs}
 setenv =
   COVERAGE_FILE=.coverage.{envname}
 deps =
@@ -84,8 +84,23 @@ commands =
 
 [testenv:flake8]
 basepython = python2.7
-deps = flake8
-commands = flake8 --doctests src tests setup.py
+deps =
+    flake8
+    flake8-html
+    flake8-coding
+    flake8-debugger
+    flake8-deprecated
+    flake8-isort
+    flake8-pep3101
+    flake8-plone-hasattr
+    flake8-polyfill
+    flake8-print
+    flake8-quotes
+    flake8-string-format
+    flake8-todo
+commands =
+    - flake8 --format=html --htmldir={toxinidir}/reports/flake8 --doctests src tests setup.py {posargs}
+    flake8 --doctests src tests setup.py {posargs}
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
this makes the Source Code of RestrictedPython consistent with the bespoken part at the Zope Sprint in Halle --> https://github.com/zopefoundation/AccessControl/pull/33#issuecomment-299422037

Should be squash merged after review.