### PR TITLE
Security issue: Ship with a default implementation for _getattr_

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,17 @@ Changes
 4.0a4 (unreleased)
 ------------------
 
-- Remove wrapping of ``len`` in write wrapper because it is unclear if this is 
+- Security issue: RestrictedPython now ships with a default implementation for
+  ``_getattr_`` which prevents from using the ``format()`` method on
+  str/unicode as it is not safe, see:
+  http://lucumr.pocoo.org/2016/12/29/careful-with-str-format/
+
+  **Caution:** If you do not already have secured the access to this
+  ``format()`` method in your ``_getattr_`` implementation use
+  ``RestrictedPython.Guards.safer_getattr()`` in your implementation to
+  benefit from this fix.
+
+- Remove wrapping of ``len`` in write wrapper because it is unclear if this is
   still needed.
 
 - Drop support of PyPy as there currently seems to be no way to restrict the

--- a/src/RestrictedPython/Guards.py
+++ b/src/RestrictedPython/Guards.py
@@ -15,11 +15,10 @@
 # AccessControl.ZopeGuards contains a large set of wrappers for builtins.
 # DocumentTemplate.DT_UTil contains a few.
 
-from . import _compat
-from ._compat import IS_PY2
+from RestrictedPython import _compat
 
 
-if IS_PY2:
+if _compat.IS_PY2:
     import __builtin__ as builtins
 else:
     # Do not attempt to use this package on Python2.7 as there
@@ -108,7 +107,7 @@ _safe_exceptions = [
     'ZeroDivisionError',
 ]
 
-if IS_PY2:
+if _compat.IS_PY2:
     _safe_names.extend([
         'basestring',
         'cmp',

--- a/src/RestrictedPython/Guards.py
+++ b/src/RestrictedPython/Guards.py
@@ -15,6 +15,7 @@
 # AccessControl.ZopeGuards contains a large set of wrappers for builtins.
 # DocumentTemplate.DT_UTil contains a few.
 
+from . import _compat
 from ._compat import IS_PY2
 
 
@@ -254,6 +255,22 @@ def guarded_delattr(object, name):
 
 
 safe_builtins['delattr'] = guarded_delattr
+
+
+def safer_getattr(object, name, getattr=getattr):
+    """Getattr implementation which prevents using format on string objects.
+
+    format() is considered harmful:
+    http://lucumr.pocoo.org/2016/12/29/careful-with-str-format/
+
+    """
+    if isinstance(object, _compat.basestring) and name == 'format':
+        raise NotImplementedError(
+            'Using format() on a %s is not safe.' % object.__class__.__name__)
+    return getattr(object, name)
+
+
+safe_builtins['_getattr_'] = safer_getattr
 
 
 def guarded_iter_unpack_sequence(it, spec, _getiter_):

--- a/src/RestrictedPython/README.rst
+++ b/src/RestrictedPython/README.rst
@@ -55,7 +55,9 @@ Specifically:
    takes two arguments.  The first is the base object to be accessed,
    while the second is the attribute name or item index that will be
    read.  The guard function should return the attribute or subitem,
-   or raise an exception.
+   or raise an exception. RestrictedPython ships with a default implementation
+   for ``_getattr_`` which prevents from using the format method of
+   strings as it is considered harmful.
 
 4. ``__import__`` is the normal Python import hook, and should be used
    to control access to Python packages and modules.

--- a/src/RestrictedPython/_compat.py
+++ b/src/RestrictedPython/_compat.py
@@ -6,3 +6,8 @@ IS_PY2 = _version.major == 2
 IS_PY3 = _version.major == 3
 IS_PY34_OR_GREATER = _version.major == 3 and _version.minor >= 4
 IS_PY35_OR_GREATER = _version.major == 3 and _version.minor >= 5
+
+if IS_PY2:
+    basestring = basestring
+else:
+    basestring = str


### PR DESCRIPTION
It prevents from using the ``format()`` method on str/unicode as it is not
safe, see: http://lucumr.pocoo.org/2016/12/29/careful-with-str-format/

This fix supersedes #80.