### PR TITLE
Warn when using another Python implementation than CPython.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@ RestrictedPython
 RestrictedPython is a tool that helps to define a subset of the Python language which allows to provide a program input into a trusted environment.
 RestrictedPython is not a sandbox system or a secured environment, but it helps to define a trusted environment and execute untrusted code inside of it.
 
+.. warning::
+
+   RestrictedPython only supports CPython. It does _not_ support PyPy and other Python implementations as it cannot provide its restrictions there.
+
 For full documentation please see http://restrictedpython.readthedocs.io/ or the local ``docs/index``.
 
 Example

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,15 +4,13 @@ Changes
 4.0b3 (unreleased)
 ------------------
 
-- Warn when using another Python implementation than CPython as it is not safe
-  to use RestrictedPython with other versions than CPyton.
+- Warn when using another Python implementation than CPython as it is not safe to use RestrictedPython with other versions than CPyton.
   See https://bitbucket.org/pypy/pypy/issues/2653 for PyPy.
 
 4.0b2 (2017-09-15)
 ------------------
 
-- Fix regression in ``RestrictionCapableEval`` which broke when using list
-  comprehensions.
+- Fix regression in ``RestrictionCapableEval`` which broke when using list comprehensions.
 
 
 4.0b1 (2017-09-15)
@@ -32,8 +30,8 @@ Changes
   `SelectCompiler.py`, `MutatingWorker.py`, `RestrictionMutator.py` and
   `tests/verify.py`.
 
-- Drop support of PyPy as there currently is no way to restrict the
-  builtins. See https://bitbucket.org/pypy/pypy/issues/2653.
+- Drop support for PyPy as there currently is no way to restrict the builtins.
+  See https://bitbucket.org/pypy/pypy/issues/2653.
 
 - Remove ``__len__`` method in ``.Guards._write_wrapper`` because it is no
   longer reachable by code using the wrapper.

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,8 +4,9 @@ Changes
 4.0b3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Warn when using another Python implementation than CPython as it is not safe
+  to use RestrictedPython with other versions than CPyton.
+  See https://bitbucket.org/pypy/pypy/issues/2653 for PyPy.
 
 4.0b2 (2017-09-15)
 ------------------
@@ -31,7 +32,7 @@ Changes
   `SelectCompiler.py`, `MutatingWorker.py`, `RestrictionMutator.py` and
   `tests/verify.py`.
 
-- Drop support of PyPy as there currently seems to be no way to restrict the
+- Drop support of PyPy as there currently is no way to restrict the
   builtins. See https://bitbucket.org/pypy/pypy/issues/2653.
 
 - Remove ``__len__`` method in ``.Guards._write_wrapper`` because it is no

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,12 @@ Welcome to RestrictedPython's documentation!
 
 .. include:: idea.rst
 
+Supported Python versions
+=========================
+
+RestrictedPython support CPython 2.7, 3.4, 3.5 and 3.6.
+It does _not_ support PyPy or other alternative Python implementations.
+
 Contents
 ========
 

--- a/src/RestrictedPython/_compat.py
+++ b/src/RestrictedPython/_compat.py
@@ -1,3 +1,4 @@
+import platform
 import sys
 
 
@@ -11,3 +12,5 @@ if IS_PY2:
     basestring = basestring  # NOQA: F821  # Python 2 only built-in function
 else:
     basestring = str
+
+IS_CPYTHON = platform.python_implementation() == 'CPython'

--- a/src/RestrictedPython/compile.py
+++ b/src/RestrictedPython/compile.py
@@ -13,8 +13,9 @@ syntax_error_template = (
     'Line {lineno}: {type}: {msg} in on statement: {statement}')
 
 NOT_CPYTHON_WARNING = (
-    'You are using on a not supported Python implementation.'
-    ' Use CPython to prevent security issues when using RestrictedPython!')
+    'RestrictedPython is only supported on CPython: use on other Python '
+    'implementations may create security issues.'
+)
 
 
 def _compile_restricted_mode(

--- a/src/RestrictedPython/compile.py
+++ b/src/RestrictedPython/compile.py
@@ -27,7 +27,8 @@ def _compile_restricted_mode(
         policy=RestrictingNodeTransformer):
 
     if not IS_CPYTHON:
-        warnings.warn(NOT_CPYTHON_WARNING, RuntimeWarning)
+        warnings.warn_explicit(
+            NOT_CPYTHON_WARNING, RuntimeWarning, 'RestrictedPython', 0)
 
     byte_code = None
     collected_errors = []

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -212,3 +212,18 @@ def test_compile___compile_restricted_mode__1(recwarn, mocker):
         'RestrictedPython is only supported on CPython: use on other Python '
         'implementations may create security issues.'
     )
+
+
+@pytest.mark.skipif(
+    platform.python_implementation() == 'CPython',
+    reason='Warning only present if not CPython.')
+def test_compile_CPython_warning(recwarn, mocker):
+    """It warns when using another Python implementation than CPython."""
+    assert platform.python_implementation() != 'CPython'
+    with pytest.warns(RuntimeWarning) as record:
+        compile_restricted('42')
+    assert len(record) == 1
+    assert str(record[0].message) == str(
+        'RestrictedPython is only supported on CPython: use on other Python '
+        'implementations may create security issues.'
+    )

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -193,3 +193,14 @@ def test_compile_restricted_eval():
     with pytest.raises(SyntaxError,
                        message="Line 3: Eval calls are not allowed."):
         compile_restricted(EVAL_EXAMPLE, '<string>', 'exec')
+
+
+def test_compile___compile_restricted_mode__1(recwarn, mocker):
+    """It warns when using another Python implementation than CPython."""
+    mocker.patch('RestrictedPython.compile.IS_CPYTHON', new=False)
+    compile_restricted('42')
+    assert len(recwarn) == 1
+    w = recwarn.pop()
+    assert w.category == RuntimeWarning
+    assert str(w.message).startswith(
+        'You are using on a not supported Python implementation.')


### PR DESCRIPTION
PyPy cannot be restricted enough by RestrictedPython.
Other implementation might have other or similar issues.