### PR TITLE
Allow a set of datatype methods like __init__ for class methods

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.0b4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow special __method__ Names in Function Definition.
+  [loechel]
 
 
 4.0b3 (2018-04-12)

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,18 +4,19 @@ Changes
 4.0b4 (unreleased)
 ------------------
 
-- Allow the following magic methods to be defined on classes. They cannot be
-  called directly but by the built-in way to us them (e. g.
+- Allow the following magic methods to be defined on classes.
+  (`#104 <https://github.com/zopefoundation/RestrictedPython/issues/104>`_)
+  They cannot be called directly but by the built-in way to use them (e. g.
   class instantiation, or comparison):
 
-  + \_\_init\_\_
-  + \_\_contains\_\_
-  + \_\_lt\_\_
-  + \_\_le\_\_
-  + \_\_eq\_\_
-  + \_\_ne\_\_
-  + \_\_gt\_\_
-  + \_\_ge\_\_
+  + ``__init__``
+  + ``__contains__``
+  + ``__lt__``
+  + ``__le__``
+  + ``__eq__``
+  + ``__ne__``
+  + ``__gt__``
+  + ``__ge__``
 
 - Imports like `from a import *` (so called star imports) are now forbidden as
   they allow to import names starting with an underscore which could override

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,8 +4,18 @@ Changes
 4.0b4 (unreleased)
 ------------------
 
-- Allow special __method__ Names in Function Definition.
-  [loechel]
+- Allow the following magic methods to be defined on classes. They cannot be
+  called directly but by the built-in way to us them (e. g.
+  class instantiation, or comparison):
+
+  + \_\_init\_\_
+  + \_\_contains\_\_
+  + \_\_lt\_\_
+  + \_\_le\_\_
+  + \_\_eq\_\_
+  + \_\_ne\_\_
+  + \_\_gt\_\_
+  + \_\_ge\_\_
 
 
 4.0b3 (2018-04-12)

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,8 @@ not_skip =
 
 [flake8]
 ignore =
+    # W503 line break before binary operator: is no longer requested by PEP-8
+    W503
 no-accept-encodings = True
 
 [coverage:run]

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -396,7 +396,8 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         if (name.startswith('_')
                 and name != '_'
                 and not (allow_magic_methods
-                         and name in ALLOWED_FUNC_NAMES)):
+                         and name in ALLOWED_FUNC_NAMES
+                         and node.col_offset != 0)):
             self.error(
                 node,
                 '"{name}" is an invalid variable name because it '

--- a/tests/transformer/test_call.py
+++ b/tests/transformer/test_call.py
@@ -105,9 +105,18 @@ def test_RestrictingNodeTransformer__visit_Call__2(e_exec, mocker):
 
 
 @pytest.mark.parametrize(*c_exec)
-def test_visit_private_function(c_exec):
-    """"""
-    result = c_exec('a = Int.__init__(1)')
+def test_visit_Call__private_function(c_exec):
+    """Calling private functions is forbidden."""
+    result = c_exec('__init__(1)')
+    assert result.errors == (
+        'Line 1: "__init__" is an invalid variable name because it starts with "_"',  # NOQA: E501
+    )
+
+
+@pytest.mark.parametrize(*c_exec)
+def test_visit_Call__private_method(c_exec):
+    """Calling private methods is forbidden."""
+    result = c_exec('Int.__init__(1)')
     assert result.errors == (
         'Line 1: "__init__" is an invalid attribute name because it starts with "_".',  # NOQA: E501
     )

--- a/tests/transformer/test_call.py
+++ b/tests/transformer/test_call.py
@@ -102,3 +102,12 @@ def test_RestrictingNodeTransformer__visit_Call__2(e_exec, mocker):
     assert ref == ret
     _apply_.assert_called_once_with(glb['foo'], *ref[0], **ref[1])
     _apply_.reset_mock()
+
+
+@pytest.mark.parametrize(*c_exec)
+def test_visit_private_function(c_exec):
+    """"""
+    result = c_exec('a = Int.__init__(1)')
+    assert result.errors == (
+        'Line 1: "__init__" is an invalid attribute name because it starts with "_".',  # NOQA: E501
+    )

--- a/tests/transformer/test_classdef.py
+++ b/tests/transformer/test_classdef.py
@@ -108,3 +108,19 @@ def test_RestrictingNodeTransformer__visit_ClassDef__5(e_exec):
     assert comb.class_att == 2342
     assert comb.base_att == 42
     assert comb.wrap_att == 23
+
+
+CONSTRUCTOR_TEST = """\
+class Test(object):
+    def __init__(self, input):
+        self.input = input
+
+"""
+
+
+@pytest.mark.parametrize(*c_exec)
+def test_RestrictedCasses_init(c_exec):
+    """Check if __init__ is allowed."""
+    result = c_exec(CONSTRUCTOR_TEST)
+    assert result.errors == ()
+    assert result.code is not None

--- a/tests/transformer/test_functiondef.py
+++ b/tests/transformer/test_functiondef.py
@@ -136,3 +136,17 @@ def test_RestrictingNodeTransformer__visit_FunctionDef__8(
         mocker.call((1, 2)),
         mocker.call((3, 4))])
     _getiter_.reset_mock()
+
+
+BLACKLISTED_FUNC_NAMES_TEST = """
+def __init__(test):
+    test
+"""
+
+
+@pytest.mark.parametrize(*c_exec)
+def test_RestrictingNodeTransformer__module_func_def_name(c_exec):
+    """"""
+    result = c_exec(BLACKLISTED_FUNC_NAMES_TEST)
+    # assert result.errors == ('Line 1: ')
+    assert result.errors == ()

--- a/tests/transformer/test_functiondef.py
+++ b/tests/transformer/test_functiondef.py
@@ -146,7 +146,7 @@ def __init__(test):
 
 @pytest.mark.parametrize(*c_exec)
 def test_RestrictingNodeTransformer__module_func_def_name(c_exec):
-    """"""
+    """It allows to define functions with the name of allowed magic methods."""
     result = c_exec(FUNC_NAMES_TEST)
     assert result.errors == ()
 
@@ -161,10 +161,9 @@ __init__(1)
 
 @pytest.mark.parametrize(*c_exec)
 def test_RestrictingNodeTransformer__module_func_def_name_call(c_exec):
-    """"""
+    """It forbids to use names of allowed magic methods."""
     result = c_exec(BLACKLISTED_FUNC_NAMES_CALL_TEST)
     # assert result.errors == ('Line 1: ')
     assert result.errors == (
-        'Line 5: Call of private method.',
         'Line 5: "__init__" is an invalid variable name because it starts with "_"',  # NOQA: E501
     )

--- a/tests/transformer/test_functiondef.py
+++ b/tests/transformer/test_functiondef.py
@@ -138,7 +138,7 @@ def test_RestrictingNodeTransformer__visit_FunctionDef__8(
     _getiter_.reset_mock()
 
 
-BLACKLISTED_FUNC_NAMES_TEST = """
+FUNC_NAMES_TEST = """
 def __init__(test):
     test
 """
@@ -147,6 +147,24 @@ def __init__(test):
 @pytest.mark.parametrize(*c_exec)
 def test_RestrictingNodeTransformer__module_func_def_name(c_exec):
     """"""
-    result = c_exec(BLACKLISTED_FUNC_NAMES_TEST)
-    # assert result.errors == ('Line 1: ')
+    result = c_exec(FUNC_NAMES_TEST)
     assert result.errors == ()
+
+
+BLACKLISTED_FUNC_NAMES_CALL_TEST = """
+def __init__(test):
+    test
+
+__init__(1)
+"""
+
+
+@pytest.mark.parametrize(*c_exec)
+def test_RestrictingNodeTransformer__module_func_def_name_call(c_exec):
+    """"""
+    result = c_exec(BLACKLISTED_FUNC_NAMES_CALL_TEST)
+    # assert result.errors == ('Line 1: ')
+    assert result.errors == (
+        'Line 5: Call of private method.',
+        'Line 5: "__init__" is an invalid variable name because it starts with "_"',  # NOQA: E501
+    )

--- a/tests/transformer/test_functiondef.py
+++ b/tests/transformer/test_functiondef.py
@@ -138,19 +138,6 @@ def test_RestrictingNodeTransformer__visit_FunctionDef__8(
     _getiter_.reset_mock()
 
 
-FUNC_NAMES_TEST = """
-def __init__(test):
-    test
-"""
-
-
-@pytest.mark.parametrize(*c_exec)
-def test_RestrictingNodeTransformer__module_func_def_name(c_exec):
-    """It allows to define functions with the name of allowed magic methods."""
-    result = c_exec(FUNC_NAMES_TEST)
-    assert result.errors == ()
-
-
 BLACKLISTED_FUNC_NAMES_CALL_TEST = """
 def __init__(test):
     test
@@ -161,9 +148,13 @@ __init__(1)
 
 @pytest.mark.parametrize(*c_exec)
 def test_RestrictingNodeTransformer__module_func_def_name_call(c_exec):
-    """It forbids to use names of allowed magic methods."""
+    """It forbids definition and usage of magic methods as functions ...
+
+    ... at module level.
+    """
     result = c_exec(BLACKLISTED_FUNC_NAMES_CALL_TEST)
     # assert result.errors == ('Line 1: ')
     assert result.errors == (
+        'Line 2: "__init__" is an invalid variable name because it starts with "_"',  # NOQA: E501
         'Line 5: "__init__" is an invalid variable name because it starts with "_"',  # NOQA: E501
     )


### PR DESCRIPTION
fix #104

It allow a subset of the python datamodel names that are implicit used in special cases.