### PR TITLE
Instead of forbidding underscore directly deprecate it for now

### DIFF
--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -452,14 +452,7 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
 
         This is a protection against rebinding dunder names like
         _getitem_, _write_ via imports.
-
-        => 'from _a import x' is ok, because '_a' is not added to the scope.
         """
-        if (isinstance(node, ast.ImportFrom)
-                and not node.module == '__future__'
-                and any(name.startswith('_') for name in node.module.split('.'))):  # NOQA: E501
-            self.error(node, 'module name starts "_", which is forbidden.')
-
         for name in node.names:
             if '*' in name.name:
                 self.error(node, '"*" imports are not allowed.')
@@ -1161,7 +1154,18 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
 
     def visit_ImportFrom(self, node):
         """Allow `import from` statements with restrictions.
-        See check_import_names."""
+        See check_import_names.
+
+        => 'from _a import x' is security wise ok,
+        because '_a' is not added to the scope.
+
+        For consistency reasons we should deprecated that and
+        forbid it in a future versions.
+        """
+        if not node.module == '__future__' and any(name.startswith('_') for name in node.module.split('.')):  # NOQA: E501
+            # self.error(node, 'module name starts "_", which is forbidden.')
+            self.warn(node, 'module name starts "_", which is deprecated and '
+                      'will be forbidden in RestrictedPython 5.')
         return self.check_import_names(node)
 
     def visit_alias(self, node):

--- a/tests/transformer/test_import.py
+++ b/tests/transformer/test_import.py
@@ -46,25 +46,37 @@ def test_RestrictingNodeTransformer__visit_Import__5(c_exec):
 
 @pytest.mark.parametrize(*c_exec)
 def test_RestrictingNodeTransformer__visit_Import__6(c_exec):
-    """Deny imports from modules staring with `_`."""
+    """Check for imports from modules starting with `_`
+    they will be deprecated in a future version."""
+    warning_message = 'Line 1: module name starts "_", which is deprecated and will be forbidden in RestrictedPython 5.'  # NOQA: E501
     result = c_exec('from _a import m')
-    assert result.errors == (
-        'Line 1: module name starts "_", which is forbidden.',
-    )
+    assert result.warnings == ([warning_message])
     result = c_exec('from a._b import m')
-    assert result.errors == (
-        'Line 1: module name starts "_", which is forbidden.',
-    )
+    assert result.warnings == ([warning_message])
     result = c_exec('from _a.b import m')
-    assert result.errors == (
-        'Line 1: module name starts "_", which is forbidden.',
-    )
+    assert result.warnings == ([warning_message])
     result = c_exec('from _a._b import m as x')
-    assert result.errors == (
-        'Line 1: module name starts "_", which is forbidden.',
-    )
-    result = c_exec('from a import m as _n')
-    assert result.errors == (import_errmsg % '_n',)
+    assert result.warnings == ([warning_message])
+    # Placeholder for future version
+    # """Deny imports from modules starting with `_`."""
+    # result = c_exec('from _a import m')
+    # assert result.errors == (
+    #     'Line 1: module name starts "_", which is forbidden.',
+    # )
+    # result = c_exec('from a._b import m')
+    # assert result.errors == (
+    #     'Line 1: module name starts "_", which is forbidden.',
+    # )
+    # result = c_exec('from _a.b import m')
+    # assert result.errors == (
+    #     'Line 1: module name starts "_", which is forbidden.',
+    # )
+    # result = c_exec('from _a._b import m as x')
+    # assert result.errors == (
+    #     'Line 1: module name starts "_", which is forbidden.',
+    # )
+    # result = c_exec('from a import m as _n')
+    # assert result.errors == (import_errmsg % '_n',)
 
 
 @pytest.mark.parametrize(*c_exec)


### PR DESCRIPTION
Based on the comment of @stephan-hof on #109 this suggest, to deprecate that behaviour first.