### PR TITLE
Fix compile_restricted_function() called with SyntaxError in function body.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -29,6 +29,10 @@ Changes
   override protected build-ins.
   (`#102 <https://github.com/zopefoundation/RestrictedPython/issues/102>`_)
 
+- When calling ``compile_restricted_function`` with a function body containing
+  a ``SyntaxError`` also a ``CompileResult`` is returned. This fixes
+  `Products.PythonScripts#11 <https://github.com/zopefoundation/Products.PythonScripts/issues/11>`_.
+
 - Bring test coverage to 100 %.
 
 - Drop support for Python 3.4.

--- a/src/RestrictedPython/compile.py
+++ b/src/RestrictedPython/compile.py
@@ -143,7 +143,16 @@ def compile_restricted_function(
     http://restrictedpython.readthedocs.io/en/latest/usage/index.html#RestrictedPython.compile_restricted_function
     """
     # Parse the parameters and body, then combine them.
-    body_ast = ast.parse(body, '<func code>', 'exec')
+    try:
+        body_ast = ast.parse(body, '<func code>', 'exec')
+    except SyntaxError as v:
+        error = syntax_error_template.format(
+            lineno=v.lineno,
+            type=v.__class__.__name__,
+            msg=v.msg,
+            statement=v.text.strip())
+        return CompileResult(
+            code=None, errors=(error,), warnings=(), used_names=())
 
     # The compiled code is actually executed inside a function
     # (that is called when the code is called) so reading and assigning to a

--- a/tests/test_compile_restricted_function.py
+++ b/tests/test_compile_restricted_function.py
@@ -203,3 +203,21 @@ def test_compile_restricted_function_allows_invalid_python_identifiers_as_functi
     assert type(generated_function) == FunctionType
     generated_function()
     assert safe_globals['output'] == 'foobar'
+
+
+@pytest.mark.parametrize(*c_function)
+def test_compile_restricted_function_handle_SyntaxError(c_function):
+    p = ''
+    body = """a("""
+    name = "broken"
+
+    result = c_function(
+        p,  # parameters
+        body,
+        name,
+    )
+
+    assert result.code is None
+    assert result.errors == (
+        "Line 1: SyntaxError: unexpected EOF while parsing at statement: 'a('",
+    )


### PR DESCRIPTION
It now also returns a `CompileResult` instead of raising a `SyntaxError`.

Fixes zopefoundation/Products.PythonScripts#11