### PR TITLE
Several checks for __builtins__ and builtins.

### DIFF
--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -70,6 +70,7 @@ ALLOWED_FUNC_NAMES = frozenset([
 FORBIDDEN_FUNC_NAMES = frozenset([
     'print',
     'printed',
+    'builtins',
 ])
 
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -48,7 +48,7 @@ mygetattr = __builtins__['getattr']
 )
 @pytest.mark.parametrize(*c_exec)
 def test_import_py2_builtins(c_exec):
-    """It should not be allowed to access global builtins in Python3."""
+    """It should not be allowed to access global __builtins__ in Python2."""
     result = c_exec(__BUILTINS_EXAMPLE)
     assert result.code is None
     assert result.errors == (
@@ -71,7 +71,7 @@ mygetattr = builtins['getattr']
 )
 @pytest.mark.parametrize(*c_exec)
 def test_import_py2_as_builtins(c_exec):
-    """It should not be allowed to access global builtins in Python3."""
+    """It should not be allowed to access global __builtins__ in Python2."""
     result = c_exec(__BUILTINS_EXAMPLE)
     assert result.code is None
     assert result.errors == (

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -3,6 +3,9 @@ Tests about imports
 """
 
 from RestrictedPython import safe_builtins
+from RestrictedPython._compat import IS_PY2
+from RestrictedPython._compat import IS_PY3
+from tests import c_exec
 from tests import e_exec
 
 import pytest
@@ -29,3 +32,92 @@ def test_os_import(e_exec):
     with pytest.raises(ImportError) as err:
         e_exec(OS_IMPORT_EXAMPLE, glb)
     assert '__import__ not found' == str(err.value)
+
+
+__BUILTINS_EXAMPLE = """
+import __builtins__
+
+mygetattr = __builtins__['getattr']
+"""
+
+
+@pytest.mark.skipif(
+    IS_PY3,
+    reason="__builtins__ has been renamed in Python3 to builtins, "
+    "so no __builtins__ in Python3."
+)
+@pytest.mark.parametrize(*c_exec)
+def test_import_py2_builtins(c_exec):
+    """It should not be allowed to access global builtins in Python3."""
+    result = c_exec(__BUILTINS_EXAMPLE)
+    assert result.code is None
+    assert result.errors == (
+        'Line 2: "__builtins__" is an invalid variable name because it starts with "_"',  # NOQA: E501
+        'Line 4: "__builtins__" is an invalid variable name because it starts with "_"'  # NOQA: E501
+    )
+
+
+__BUILTINS_AS_EXAMPLE = """
+import __builtins__ as builtins
+
+mygetattr = builtins['getattr']
+"""
+
+
+@pytest.mark.skipif(
+    IS_PY3,
+    reason="__builtins__ has been renamed in Python3 to builtins, "
+    "so no __builtins__ in Python3."
+)
+@pytest.mark.parametrize(*c_exec)
+def test_import_py2_as_builtins(c_exec):
+    """It should not be allowed to access global builtins in Python3."""
+    result = c_exec(__BUILTINS_EXAMPLE)
+    assert result.code is None
+    assert result.errors == (
+        'Line 2: "__builtins__" is an invalid variable name because it starts with "_"',  # NOQA: E501
+        'Line 4: "__builtins__" is an invalid variable name because it starts with "_"'  # NOQA: E501
+    )
+
+
+BUILTINS_EXAMPLE = """
+import builtins
+
+mygetattr = builtins['getattr']
+"""
+
+
+@pytest.mark.skipif(
+    IS_PY2,
+    reason="__builtins__ has been renamed in Python3 to builtins, "
+    "and need only to be tested there."
+)
+@pytest.mark.parametrize(*c_exec)
+def test_import_py3_builtins(c_exec):
+    """It should not be allowed to access global builtins in Python3."""
+    result = c_exec(BUILTINS_EXAMPLE)
+    assert result.code is None
+    assert result.errors == (
+        'Line 2: "builtins" is a reserved name.',
+        'Line 4: "builtins" is a reserved name.'
+    )
+
+
+BUILTINS_AS_EXAMPLE = """
+import builtins as glb
+
+mygetattr = glb['getattr']
+"""
+
+
+@pytest.mark.skipif(
+    IS_PY2,
+    reason="__builtins__ has been renamed in Python3 to builtins, "
+    "and need only to be tested there."
+)
+@pytest.mark.parametrize(*c_exec)
+def test_import_py3_as_builtins(c_exec):
+    """It should not be allowed to access global builtins in Python3."""
+    result = c_exec(BUILTINS_AS_EXAMPLE)
+    assert result.code is None
+    assert result.errors == ('Line 2: "builtins" is a reserved name.',)


### PR DESCRIPTION
builtins is a dangerous element in RestrictedPython, as it contains the whole Programming Environment with all modules and control access to them.
Should be forbidden to access.

Fixes #115