### PR TITLE
fix error if a SyntaxError is raised, but no text is provided

### DIFF
--- a/src/RestrictedPython/compile.py
+++ b/src/RestrictedPython/compile.py
@@ -60,7 +60,7 @@ def _compile_restricted_mode(
                     lineno=v.lineno,
                     type=v.__class__.__name__,
                     msg=v.msg,
-                    statement=v.text.strip()
+                    statement=v.text.strip() if v.text else None
                 ))
         if c_ast:
             policy_instance = policy(

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -31,6 +31,17 @@ def test_compile__compile_restricted_invalid_mode_input():
         compile_restricted("pass", '<string>', 'invalid')
 
 
+INVALID_ASSINGMENT = """
+1 = 2
+"""
+
+
+def test_compile__invalid_syntax():
+    with pytest.raises(SyntaxError) as err:
+        compile_restricted(INVALID_ASSINGMENT, '<string>', 'exec')
+    assert "can't assign to literal at statement:" in str(err.value)
+
+
 @pytest.mark.parametrize(*c_exec)
 def test_compile__compile_restricted_exec__1(c_exec):
     """It returns a CompileResult on success."""


### PR DESCRIPTION
this fixes #125 