### PR TITLE
WIP: start testing for Python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
         'allows to provide a program input into a trusted environment.'
     ),
     long_description=(
-        read('README.rst') + '\n' +
-        read('docs', 'CHANGES.rst')
+        read('README.rst') + '\n'
+        + read('docs', 'CHANGES.rst')
     ),
     classifiers=[
         'License :: OSI Approved :: Zope Public License',

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -568,15 +568,23 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         return self.node_contents_visit(node)
 
     def visit_Ellipsis(self, node):
-        """Deny using `...`.
+        """Allow using `...`.
 
         Ellipsis is exists only in Python 3.
         """
-        self.not_allowed(node)
+        return self.node_contents_visit(node)
 
     def visit_NameConstant(self, node):
         """
 
+        """
+        return self.node_contents_visit(node)
+
+    def visit_Constant(self, node):
+        """
+
+        Constant replaces Num, Str, Byte, NameConstant and Ellipsis
+        :see: https://docs.python.org/dev/whatsnew/3.8.html#deprecated
         """
         return self.node_contents_visit(node)
 

--- a/tests/transformer/test_base_types.py
+++ b/tests/transformer/test_base_types.py
@@ -1,3 +1,4 @@
+from RestrictedPython import compile_restricted_eval
 from RestrictedPython._compat import IS_PY2
 from tests import c_exec
 from tests import e_eval
@@ -29,4 +30,5 @@ def test_Set(e_eval):
 def test_Ellipsis(c_exec):
     """It prevents using the `ellipsis` statement."""
     result = c_exec('...')
-    assert result.errors == ('Line 1: Ellipsis statements are not allowed.',)
+    assert result.errors == ()
+    assert eval(compile_restricted_eval('...').code, {})

--- a/tests/transformer/test_slice.py
+++ b/tests/transformer/test_slice.py
@@ -1,4 +1,7 @@
 from operator import getitem
+from RestrictedPython import compile_restricted_eval
+from RestrictedPython import compile_restricted_exec
+from RestrictedPython._compat import IS_PY2
 from tests import e_eval
 
 import pytest
@@ -21,3 +24,37 @@ def test_slice(e_eval):
     assert e_eval('[1, 2, 3, 4, 5][%d::%d]' % (low, stride), rglb) == [2, 5]
     assert e_eval('[1, 2, 3, 4, 5][:%d:%d]' % (high, stride), rglb) == [1, 4]
     assert e_eval('[1, 2, 3, 4, 5][%d:%d:%d]' % (low, high, stride), rglb) == [2]  # NOQA: E501
+
+
+@pytest.mark.xfail
+@pytest.mark.skipif(
+    IS_PY2,
+    reason="Ellipsis is Python 3 only."
+)
+def test_ellipsis_slice_01():
+    rglb = {'_getitem_': getitem}  # restricted globals
+
+    assert eval(
+        compile_restricted_eval(
+            '[1, 2, 3, 4, 5, 6, 7] == [1, 2, 3, ... , 7]'
+        ).code,
+        rglb
+    ) is True
+
+
+ELLIPSIS_EXAMPLE = """
+def first_last(input_list):
+    first , ..., last = input_list
+    return (first, last)
+"""
+
+
+@pytest.mark.skipif(
+    IS_PY2,
+    reason="Ellipsis is Python 3 only."
+)
+def test_ellipsis_slice_02():
+    result = compile_restricted_exec(ELLIPSIS_EXAMPLE)
+    assert result.errors == ()
+    assert result.warnings == []
+    assert result.code is not None

--- a/tests/transformer/test_slice.py
+++ b/tests/transformer/test_slice.py
@@ -43,9 +43,11 @@ def test_ellipsis_slice_01():
 
 
 ELLIPSIS_EXAMPLE = """
-def first_last(input_list):
-    first, ..., last = input_list
-    return (first, last)
+from array import Array
+
+data_array = Array('l', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+
+data[1, ..., 1]
 """
 
 

--- a/tests/transformer/test_slice.py
+++ b/tests/transformer/test_slice.py
@@ -44,7 +44,7 @@ def test_ellipsis_slice_01():
 
 ELLIPSIS_EXAMPLE = """
 def first_last(input_list):
-    first , ..., last = input_list
+    first, ..., last = input_list
     return (first, last)
 """
 

--- a/tests/transformer/test_slice.py
+++ b/tests/transformer/test_slice.py
@@ -43,11 +43,13 @@ def test_ellipsis_slice_01():
 
 
 ELLIPSIS_EXAMPLE = """
-from array import Array
+from array import array
 
-data_array = Array('l', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+def get_data():
+    data_array = array('l', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 
-data[1, ..., 1]
+    return data_array[1, ..., 1]
+
 """
 
 
@@ -60,3 +62,7 @@ def test_ellipsis_slice_02():
     assert result.errors == ()
     assert result.warnings == []
     assert result.code is not None
+    rglb = {'_getitem_': getitem}  # restricted globals
+    lcs = {}
+    exec(result.code, rglb, lcs)
+    assert lcs['get_data']() == ""

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py36,
     py36-datetime,
     py37,
+    py38,
 #    pypy,
 #    pypy3,
     docs,


### PR DESCRIPTION
This is WIP to solve #140 

Please do not merge or review now.

# Discussion

Deprecation of several AST Elements (Num, Str, Byte, NameConstant and Ellipsis --> https://docs.python.org/dev/whatsnew/3.8.html#deprecated) in favore of Constant seem either to handle the special case Ellipses in there separately or to allow Ellipses statements. I tend to second option, but this will need more tests.