### PR TITLE
lint config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,31 +7,31 @@ matrix:
 environment:
   matrix:
     - PROFILE: py27-conventions
-      PYTHON_VERSION: 2.7"
+      PYTHON_VERSION: "2.7"
       TOXENV: "lint,docs"
     - PROFILE: py35-conventions
-      PYTHON_VERSION: 3.6"
+      PYTHON_VERSION: "3.6"
       TOXENV: "lint,docs"
     - PROFILE: py36-conventions
-      PYTHON_VERSION: 3.6"
+      PYTHON_VERSION: "3.6"
       TOXENV: "lint,docs"
     - PROFILE: py37-conventions
-      PYTHON_VERSION: 3.6"
+      PYTHON_VERSION: "3.6"
       TOXENV: "lint,docs"
     - PROFILE: py27
-      PYTHON_VERSION: 2.7"
+      PYTHON_VERSION: "2.7"
       TOXENV: "py27,py27-datetime"
     - PROFILE: py35
-      PYTHON_VERSION: 3.5"
+      PYTHON_VERSION: "3.5"
       TOXENV: "py35,py35-datetime"
     - PROFILE: py36
-      PYTHON_VERSION: 3.6"
+      PYTHON_VERSION: "3.6"
       TOXENV: "py36,py36-datetime"
     - PROFILE: py37
-      PYTHON_VERSION: 3.7"
+      PYTHON_VERSION: "3.7"
       TOXENV: "py37,py37-datetime"
     - PROFILE: py38
-      PYTHON_VERSION: 3.8"
+      PYTHON_VERSION: "3.8"
       TOXENV: "py38,py38-datetime"
 
 

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
         'allows to provide a program input into a trusted environment.'
     ),
     long_description=(
-        read('README.rst') + '\n' +
-        read('docs', 'CHANGES.rst')
+        read('README.rst') + '\n'
+        + read('docs', 'CHANGES.rst')
     ),
     classifiers=[
         'License :: OSI Approved :: Zope Public License',

--- a/tox.ini
+++ b/tox.ini
@@ -105,7 +105,7 @@ deps =
 
 commands =
     mkdir -p {toxinidir}/_build/flake8
-    isort --check-only --recursive {toxinidir}/src {toxinidir}/tests setup.py
+    - isort --check-only --recursive {toxinidir}/src {toxinidir}/tests setup.py
     - flake8 --format=html --htmldir={toxinidir}/_build/flake8 --doctests src tests setup.py
     flake8 src tests setup.py --doctests
 


### PR DESCRIPTION
* make the isort explicite check result ignored, as that is also in the flake8 check via flake8-isort, so we always got the full problem list. 
* fix one linting issue in setup.py