### PR TITLE
There's no Python 3.8 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,9 @@
 # AppVeyor CI settings (Windows Machine CI Tests)
 
-matrix:
-  allow_failures:
-    - PROFILE: py38
-
 environment:
   matrix:
     - PROFILE: py27-conventions
       PYTHON_VERSION: "2.7"
-      TOXENV: "lint,docs"
-    - PROFILE: py35-conventions
-      PYTHON_VERSION: "3.6"
-      TOXENV: "lint,docs"
-    - PROFILE: py36-conventions
-      PYTHON_VERSION: "3.6"
-      TOXENV: "lint,docs"
-    - PROFILE: py37-conventions
-      PYTHON_VERSION: "3.6"
       TOXENV: "lint,docs"
     - PROFILE: py27
       PYTHON_VERSION: "2.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 
 matrix:
   allow_failures:
-  - PROFILE: py38
+    - PROFILE: py38
 
 environment:
   matrix:
@@ -30,10 +30,6 @@ environment:
     - PROFILE: py37
       PYTHON_VERSION: "3.7"
       TOXENV: "py37,py37-datetime"
-    - PROFILE: py38
-      PYTHON_VERSION: "3.8"
-      TOXENV: "py38,py38-datetime"
-
 
 
 cache:


### PR DESCRIPTION
https://www.appveyor.com/docs/windows-images-software/#python does not
list Python 3.8 as an available version.

(In fact Python 3.8 is not out yet.)

Having it listed in appveyor.yml confuses tools like my
check-python-versions, as they detect an inconsistency between supported
Python versions listed in appveyor.yml with those listed eg. in
setup.py.