### PR TITLE
fixes #155, remove deprecation warning about print statement. 

### DIFF
--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -1135,12 +1135,7 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         templates and scripts; 'write' happens to be the name of the
         method that changes them.
         """
-
         self.print_info.print_used = True
-        self.warn(node,
-                  "Print statement is deprecated and "
-                  "not available anymore in Python 3.")
-
         node = self.node_contents_visit(node)
         if node.dest is None:
             node.dest = ast.Name('_print', ast.Load())

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -182,11 +182,8 @@ def test_compile_restricted():
         # Non-CPython versions have a RuntimeWarning, too.
         if len(record) > 2:  # pragma: no cover
             record.pop()
-        assert len(record) == 2
+        assert len(record) == 1
         assert record[0].message.args[0] == \
-            'Line 3: Print statement is deprecated ' \
-            'and not available anymore in Python 3.'
-        assert record[1].message.args[0] == \
             "Line 2: Prints, but never reads 'printed' variable."
 
 

--- a/tests/test_print_stmt.py
+++ b/tests/test_print_stmt.py
@@ -171,7 +171,6 @@ def test_print_stmt__with_printed_no_print_nested():
     assert code is not None
     assert errors == ()
     assert warnings == [
-        "Line 2: Print statement is deprecated and not available anymore in Python 3.",  # NOQA: E501
         "Line 3: Doesn't print, but reads 'printed' variable."
     ]
 
@@ -188,7 +187,6 @@ def test_print_stmt__with_print_no_printed():
     assert code is not None
     assert errors == ()
     assert warnings == [
-        "Line 3: Print statement is deprecated and not available anymore in Python 3.",  # NOQA: E501
         "Line 2: Prints, but never reads 'printed' variable."
     ]
 
@@ -208,8 +206,6 @@ def test_print_stmt__with_print_no_printed_nested():
     assert code is not None
     assert errors == ()
     assert warnings == [
-        "Line 2: Print statement is deprecated and not available anymore in Python 3.",  # NOQA: E501
-        "Line 4: Print statement is deprecated and not available anymore in Python 3.",  # NOQA: E501
         "Line 3: Prints, but never reads 'printed' variable.",
     ]
 


### PR DESCRIPTION
Its useless because a) its wrong, since its also displayed when you already use the print function and b) the actual error message when using py3 is far more precise and useful and finally c) we don't use deprecation warnings elsewhere