### PR TITLE
Added statement to resolve getiter error

### DIFF
--- a/docs/usage/basic_usage.rst
+++ b/docs/usage/basic_usage.rst
@@ -104,6 +104,7 @@ To use classes in Python 3
     ``__metaclass__`` must be set. Set it to ``type`` to use no custom metaclass.
 
 To use ``for`` statements and comprehensions
+    ``_getiter_`` must point to :func:`RestrictedPython.Eval.default_guarded_getiter` and
     ``_iter_unpack_sequence_`` must point to :func:`RestrictedPython.Guards.guarded_iter_unpack_sequence`.
 
 To use ``getattr``


### PR DESCRIPTION
When using for loops, we faced the error `_getiter_` not defined. This is the workaround for resolving it.