### PR TITLE
Add support for f-strings

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added support for f-strings in Python 3.6+.
+  (`#123 <https://github.com/zopefoundation/RestrictedPython/issues/123>`_)
 
 
 4.0 (2019-05-10)

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -574,6 +574,14 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         """Allow dict literals without restrictions."""
         return self.node_contents_visit(node)
 
+    def visit_FormattedValue(self, node):
+        """Allow f-strings without restrictions."""
+        return self.node_contents_visit(node)
+
+    def visit_JoinedStr(self, node):
+        """Allow joined string without restrictions."""
+        return self.node_contents_visit(node)
+
     def visit_Constant(self, node):
         """Allow constant literals without restrictions.
 

--- a/tests/transformer/test_fstring.py
+++ b/tests/transformer/test_fstring.py
@@ -1,0 +1,31 @@
+from RestrictedPython import compile_restricted_exec
+from tests.helper import restricted_exec
+
+from sys import version_info
+
+
+def test_transform():
+    """It compiles a function call successfully and returns the used name."""
+
+    # F-strings were introduced in Python 3.6.
+    if version_info.major >= 3 and version_info.minor >= 6:
+        result = compile_restricted_exec('a = f"{max([1, 2, 3])}"')
+        assert result.errors == ()
+        loc = {}
+        exec(result.code, {}, loc)
+        assert loc['a'] == '3'
+        assert result.used_names == {'max': True}
+
+
+def test_visit_invalid_variable_name():
+    """Accessing private attributes is forbidden.
+
+    This is just a smoke test to validate that restricted exec is used
+    in the run-time evaluation of f-strings.
+    """
+    # F-strings were introduced in Python 3.6.
+    if version_info.major >= 3 and version_info.minor >= 6:
+        result = compile_restricted_exec('f"{__init__}"')
+        assert result.errors == (
+            'Line 1: "__init__" is an invalid variable name because it starts with "_"',  # NOQA: E501
+        )

--- a/tests/transformer/test_fstring.py
+++ b/tests/transformer/test_fstring.py
@@ -1,31 +1,32 @@
 from RestrictedPython import compile_restricted_exec
+from RestrictedPython._compat import IS_PY36_OR_GREATER
 from tests.helper import restricted_exec
 
 from sys import version_info
 
+import pytest
 
+
+@pytest.mark.skipif(not IS_PY36_OR_GREATER, reason="F-strings added in Python 3.6.")
 def test_transform():
     """It compiles a function call successfully and returns the used name."""
 
-    # F-strings were introduced in Python 3.6.
-    if version_info.major >= 3 and version_info.minor >= 6:
-        result = compile_restricted_exec('a = f"{max([1, 2, 3])}"')
-        assert result.errors == ()
-        loc = {}
-        exec(result.code, {}, loc)
-        assert loc['a'] == '3'
-        assert result.used_names == {'max': True}
+    result = compile_restricted_exec('a = f"{max([1, 2, 3])}"')
+    assert result.errors == ()
+    loc = {}
+    exec(result.code, {}, loc)
+    assert loc['a'] == '3'
+    assert result.used_names == {'max': True}
 
 
+@pytest.mark.skipif(not IS_PY36_OR_GREATER, reason="F-strings added in Python 3.6.")
 def test_visit_invalid_variable_name():
     """Accessing private attributes is forbidden.
 
     This is just a smoke test to validate that restricted exec is used
     in the run-time evaluation of f-strings.
     """
-    # F-strings were introduced in Python 3.6.
-    if version_info.major >= 3 and version_info.minor >= 6:
-        result = compile_restricted_exec('f"{__init__}"')
-        assert result.errors == (
-            'Line 1: "__init__" is an invalid variable name because it starts with "_"',  # NOQA: E501
-        )
+    result = compile_restricted_exec('f"{__init__}"')
+    assert result.errors == (
+        'Line 1: "__init__" is an invalid variable name because it starts with "_"',  # NOQA: E501
+    )


### PR DESCRIPTION
This fixes #123.

Note that f-strings are very different from using `str.format` since they're actually compiled to bytecode and thus the restricted exec transformer is able to work its magic on the expression contained.