### PR TITLE
Partial Revert of Merge/Pull-Request #150 - Disallow Ellipsis again.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,6 +8,14 @@ Changes
   (`#123 <https://github.com/zopefoundation/RestrictedPython/issues/123>`_)
 
 
+Breaking changes
+----------------
+
+- Revert the Allowance of the ``...`` (Ellipsis) statement, as of 4.0. It is not needed to support Python 3.8.
+  The security implications of the Ellipsis Statement is not 100 % clear and is not checked.
+  ``...`` (Ellipsis) is disallowed again.
+
+
 4.0 (2019-05-10)
 ----------------
 

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -583,21 +583,29 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         return self.node_contents_visit(node)
 
     def visit_Constant(self, node):
-        """Allow constant literals without restrictions.
+        """Allow constant literals with restriction for Ellipsis.
 
         Constant replaces Num, Str, Bytes, NameConstant and Ellipsis in
         Python 3.8+.
         :see: https://docs.python.org/dev/whatsnew/3.8.html#deprecated
         """
+        if node.value is Ellipsis:
+            # Deny using `...`.
+            # Special handling necessary as ``self.not_allowed(node)``
+            # would return the Error Message:
+            # 'Constant statements are not allowed.'
+            # which is only partial true.
+            self.error(node, 'Ellipsis statements are not allowed.')
+            return
         return self.node_contents_visit(node)
 
     def visit_Ellipsis(self, node):
-        """Allow using `...`.
+        """Deny using `...`.
 
         Ellipsis is exists only in Python 3.
         Replaced by Constant in Python 3.8.
         """
-        return self.node_contents_visit(node)
+        return self.not_allowed(node)
 
     def visit_NameConstant(self, node):
         """Allow constant literals (True, False, None) without restrictions.

--- a/tests/transformer/test_base_types.py
+++ b/tests/transformer/test_base_types.py
@@ -1,3 +1,4 @@
+from RestrictedPython import compile_restricted_exec
 from RestrictedPython._compat import IS_PY2
 from tests.helper import restricted_eval
 
@@ -22,5 +23,6 @@ def test_Set():
 @pytest.mark.skipif(IS_PY2,
                     reason="... is new in Python 3")
 def test_Ellipsis():
-    """It allows using the `...` statement."""
-    assert restricted_eval('...') == Ellipsis
+    """It prevents using the `ellipsis` statement."""
+    result = compile_restricted_exec('...')
+    assert result.errors == ('Line 1: Ellipsis statements are not allowed.',)


### PR DESCRIPTION
Ellipsis is not necessary to allow for the changes in Python 3.8, where Constant replaces Num, Str, Bytes, NameConstant and Ellipsis.
https://docs.python.org/dev/whatsnew/3.8.html\#deprecated

https://bugs.python.org/issue36917\#msg342583 shows a better solution to check for Ellipsis, so we could go back to old and more secure behaviour.

So it partial reverts #150 