### PR TITLE
readd some of the documentation that helps to understand how RestrictedPython works internally

### DIFF
--- a/docs/contributing/ast/python2_6.ast
+++ b/docs/contributing/ast/python2_6.ast
@@ -1,0 +1,142 @@
+-- Python 2.6 AST
+-- ASDL's five builtin types are identifier, int, string, object, bool
+
+module Python version "2.6"
+{
+  mod = Module(stmt* body)
+      | Interactive(stmt* body)
+      | Expression(expr body)
+
+      -- not really an actual node but useful in Jython's typesystem.
+      | Suite(stmt* body)
+
+  stmt = FunctionDef(identifier name, arguments args,
+                            stmt* body, expr* decorator_list)
+        | ClassDef(identifier name, expr* bases, stmt* body, expr *decorator_list)
+        | Return(expr? value)
+
+        | Delete(expr* targets)
+        | Assign(expr* targets, expr value)
+        | AugAssign(expr target, operator op, expr value)
+
+        -- not sure if bool is allowed, can always use int
+ 	      | Print(expr? dest, expr* values, bool nl)
+
+        -- use 'orelse' because else is a keyword in target languages
+        | For(expr target, expr iter, stmt* body, stmt* orelse)
+        | While(expr test, stmt* body, stmt* orelse)
+        | If(expr test, stmt* body, stmt* orelse)
+        | With(expr context_expr, expr? optional_vars, stmt* body)
+
+        -- 'type' is a bad name
+        | Raise(expr? type, expr? inst, expr? tback)
+        | TryExcept(stmt* body, excepthandler* handlers, stmt* orelse)
+        | TryFinally(stmt* body, stmt* finalbody)
+        | Assert(expr test, expr? msg)
+
+        | Import(alias* names)
+        | ImportFrom(identifier module, alias* names, int? level)
+
+        -- Doesn't capture requirement that locals must be
+        -- defined if globals is
+        -- still supports use as a function!
+        | Exec(expr body, expr? globals, expr? locals)
+
+        | Global(identifier* names)
+        | Expr(expr value)
+        | Pass | Break | Continue
+
+        -- XXX Jython will be different
+        -- col_offset is the byte offset in the utf8 string the parser uses
+        attributes (int lineno, int col_offset)
+
+        -- BoolOp() can use left & right?
+  expr = BoolOp(boolop op, expr* values)
+       | BinOp(expr left, operator op, expr right)
+       | UnaryOp(unaryop op, expr operand)
+       | Lambda(arguments args, expr body)
+       | IfExp(expr test, expr body, expr orelse)
+       | Dict(expr* keys, expr* values)
+       | ListComp(expr elt, comprehension* generators)
+       | GeneratorExp(expr elt, comprehension* generators)
+       -- the grammar constrains where yield expressions can occur
+       | Yield(expr? value)
+       -- need sequences for compare to distinguish between
+       -- x < 4 < 3 and (x < 4) < 3
+       | Compare(expr left, cmpop* ops, expr* comparators)
+       | Call(expr func, expr* args, keyword* keywords,
+       expr? starargs, expr? kwargs)
+       | Repr(expr value)
+       | Num(object n) -- a number as a PyObject.
+       | Str(string s) -- need to specify raw, unicode, etc?
+       -- other literals? bools?
+
+       -- the following expression can appear in assignment context
+       | Attribute(expr value, identifier attr, expr_context ctx)
+       | Subscript(expr value, slice slice, expr_context ctx)
+       | Name(identifier id, expr_context ctx)
+       | List(expr* elts, expr_context ctx)
+       | Tuple(expr* elts, expr_context ctx)
+
+        -- col_offset is the byte offset in the utf8 string the parser uses
+        attributes (int lineno, int col_offset)
+
+  expr_context = Load
+               | Store
+               | Del
+               | AugLoad
+               | AugStore
+               | Param
+
+  slice = Ellipsis
+        | Slice(expr? lower, expr? upper, expr? step)
+        | ExtSlice(slice* dims)
+        | Index(expr value)
+
+  boolop = And
+         | Or
+
+  operator = Add
+           | Sub
+           | Mult
+           | Div
+           | Mod
+           | Pow
+           | LShift
+           | RShift
+           | BitOr
+           | BitXor
+           | BitAnd
+           | FloorDiv
+
+  unaryop = Invert
+          | Not
+          | UAdd
+          | USub
+
+  cmpop = Eq
+        | NotEq
+        | Lt
+        | LtE
+        | Gt
+        | GtE
+        | Is
+        | IsNot
+        | In
+        | NotIn
+
+  comprehension = (expr target, expr iter, expr* ifs)
+
+  -- not sure what to call the first argument for raise and except
+  excepthandler = ExceptHandler(expr? type, expr? name, stmt* body)
+                  attributes (int lineno, int col_offset)
+
+  arguments = (expr* args, identifier? vararg,
+               identifier? kwarg, expr* defaults)
+
+  -- keyword arguments supplied to call
+  keyword = (identifier arg, expr value)
+
+  -- import name with optional 'as' alias.
+  alias = (identifier name, identifier? asname)
+}

--- a/docs/contributing/ast/python2_6.ast
+++ b/docs/contributing/ast/python2_6.ast
@@ -10,8 +10,10 @@ module Python version "2.6"
       -- not really an actual node but useful in Jython's typesystem.
       | Suite(stmt* body)
 
-  stmt = FunctionDef(identifier name, arguments args,
-                            stmt* body, expr* decorator_list)
+  stmt = FunctionDef(identifier name,
+                     arguments args,
+                     stmt* body,
+                     expr* decorator_list)
         | ClassDef(identifier name, expr* bases, stmt* body, expr *decorator_list)
         | Return(expr? value)
 
@@ -20,7 +22,7 @@ module Python version "2.6"
         | AugAssign(expr target, operator op, expr value)
 
         -- not sure if bool is allowed, can always use int
- 	      | Print(expr? dest, expr* values, bool nl)
+ 	  | Print(expr? dest, expr* values, bool nl)
 
         -- use 'orelse' because else is a keyword in target languages
         | For(expr target, expr iter, stmt* body, stmt* orelse)
@@ -64,8 +66,7 @@ module Python version "2.6"
        -- need sequences for compare to distinguish between
        -- x < 4 < 3 and (x < 4) < 3
        | Compare(expr left, cmpop* ops, expr* comparators)
-       | Call(expr func, expr* args, keyword* keywords,
-       expr? starargs, expr? kwargs)
+       | Call(expr func, expr* args, keyword* keywords, expr? starargs, expr? kwargs)
        | Repr(expr value)
        | Num(object n) -- a number as a PyObject.
        | Str(string s) -- need to specify raw, unicode, etc?

--- a/docs/contributing/ast/python2_7.ast
+++ b/docs/contributing/ast/python2_7.ast
@@ -1,0 +1,144 @@
+-- Python 2.7 AST
+-- ASDL's five builtin types are identifier, int, string, object, bool
+
+module Python version "2.7"
+{
+  mod = Module(stmt* body)
+      | Interactive(stmt* body)
+      | Expression(expr body)
+
+      -- not really an actual node but useful in Jython's typesystem.
+      | Suite(stmt* body)
+
+  stmt = FunctionDef(identifier name, arguments args,
+                     stmt* body, expr* decorator_list)
+        | ClassDef(identifier name, expr* bases, stmt* body, expr* decorator_list)
+        | Return(expr? value)
+
+        | Delete(expr* targets)
+        | Assign(expr* targets, expr value)
+        | AugAssign(expr target, operator op, expr value)
+
+        -- not sure if bool is allowed, can always use int
+ 	      | Print(expr? dest, expr* values, bool nl)
+
+        -- use 'orelse' because else is a keyword in target languages
+        | For(expr target, expr iter, stmt* body, stmt* orelse)
+        | While(expr test, stmt* body, stmt* orelse)
+        | If(expr test, stmt* body, stmt* orelse)
+        | With(expr context_expr, expr? optional_vars, stmt* body)
+
+        -- 'type' is a bad name
+        | Raise(expr? type, expr? inst, expr? tback)
+        | TryExcept(stmt* body, excepthandler* handlers, stmt* orelse)
+        | TryFinally(stmt* body, stmt* finalbody)
+        | Assert(expr test, expr? msg)
+
+        | Import(alias* names)
+        | ImportFrom(identifier? module, alias* names, int? level)
+
+        -- Doesn't capture requirement that locals must be
+        -- defined if globals is
+        -- still supports use as a function!
+        | Exec(expr body, expr? globals, expr? locals)
+
+        | Global(identifier* names)
+        | Expr(expr value)
+        | Pass | Break | Continue
+
+        -- XXX Jython will be different
+        -- col_offset is the byte offset in the utf8 string the parser uses
+        attributes (int lineno, int col_offset)
+
+        -- BoolOp() can use left & right?
+  expr = BoolOp(boolop op, expr* values)
+       | BinOp(expr left, operator op, expr right)
+       | UnaryOp(unaryop op, expr operand)
+       | Lambda(arguments args, expr body)
+       | IfExp(expr test, expr body, expr orelse)
+       | Dict(expr* keys, expr* values)
+       | Set(expr* elts)
+       | ListComp(expr elt, comprehension* generators)
+       | SetComp(expr elt, comprehension* generators)
+       | DictComp(expr key, expr value, comprehension* generators)
+       | GeneratorExp(expr elt, comprehension* generators)
+       -- the grammar constrains where yield expressions can occur
+       | Yield(expr? value)
+       -- need sequences for compare to distinguish between
+       -- x < 4 < 3 and (x < 4) < 3
+       | Compare(expr left, cmpop* ops, expr* comparators)
+       | Call(expr func, expr* args, keyword* keywords,
+       expr? starargs, expr? kwargs)
+       | Repr(expr value)
+       | Num(object n) -- a number as a PyObject.
+       | Str(string s) -- need to specify raw, unicode, etc?
+       -- other literals? bools?
+
+       -- the following expression can appear in assignment context
+       | Attribute(expr value, identifier attr, expr_context ctx)
+       | Subscript(expr value, slice slice, expr_context ctx)
+       | Name(identifier id, expr_context ctx)
+       | List(expr* elts, expr_context ctx)
+       | Tuple(expr* elts, expr_context ctx)
+
+        -- col_offset is the byte offset in the utf8 string the parser uses
+        attributes (int lineno, int col_offset)
+
+  expr_context = Load
+               | Store
+               | Del
+               | AugLoad
+               | AugStore
+               | Param
+
+  slice = Ellipsis
+        | Slice(expr? lower, expr? upper, expr? step)
+        | ExtSlice(slice* dims)
+        | Index(expr value)
+
+  boolop = And | Or
+
+  operator = Add
+           | Sub
+           | Mult
+           | Div
+           | Mod
+           | Pow
+           | LShift
+           | RShift
+           | BitOr
+           | BitXor
+           | BitAnd
+           | FloorDiv
+
+  unaryop = Invert
+          | Not
+          | UAdd
+          | USub
+
+  cmpop = Eq
+        | NotEq
+        | Lt
+        | LtE
+        | Gt
+        | GtE
+        | Is
+        | IsNot
+        | In
+        | NotIn
+
+  comprehension = (expr target, expr iter, expr* ifs)
+
+  -- not sure what to call the first argument for raise and except
+  excepthandler = ExceptHandler(expr? type, expr? name, stmt* body)
+                  attributes (int lineno, int col_offset)
+
+  arguments = (expr* args, identifier? vararg,
+               identifier? kwarg, expr* defaults)
+
+  -- keyword arguments supplied to call
+  keyword = (identifier arg, expr value)
+
+  -- import name with optional 'as' alias.
+  alias = (identifier name, identifier? asname)
+}

--- a/docs/contributing/ast/python2_7.ast
+++ b/docs/contributing/ast/python2_7.ast
@@ -10,8 +10,10 @@ module Python version "2.7"
       -- not really an actual node but useful in Jython's typesystem.
       | Suite(stmt* body)
 
-  stmt = FunctionDef(identifier name, arguments args,
-                     stmt* body, expr* decorator_list)
+  stmt = FunctionDef(identifier name,
+                     arguments args,
+                     stmt* body,
+                     expr* decorator_list)
         | ClassDef(identifier name, expr* bases, stmt* body, expr* decorator_list)
         | Return(expr? value)
 
@@ -20,7 +22,7 @@ module Python version "2.7"
         | AugAssign(expr target, operator op, expr value)
 
         -- not sure if bool is allowed, can always use int
- 	      | Print(expr? dest, expr* values, bool nl)
+ 	  | Print(expr? dest, expr* values, bool nl)
 
         -- use 'orelse' because else is a keyword in target languages
         | For(expr target, expr iter, stmt* body, stmt* orelse)
@@ -67,8 +69,7 @@ module Python version "2.7"
        -- need sequences for compare to distinguish between
        -- x < 4 < 3 and (x < 4) < 3
        | Compare(expr left, cmpop* ops, expr* comparators)
-       | Call(expr func, expr* args, keyword* keywords,
-       expr? starargs, expr? kwargs)
+       | Call(expr func, expr* args, keyword* keywords, expr? starargs, expr? kwargs)
        | Repr(expr value)
        | Num(object n) -- a number as a PyObject.
        | Str(string s) -- need to specify raw, unicode, etc?
@@ -96,7 +97,8 @@ module Python version "2.7"
         | ExtSlice(slice* dims)
         | Index(expr value)
 
-  boolop = And | Or
+  boolop = And
+         | Or
 
   operator = Add
            | Sub

--- a/docs/contributing/ast/python3_0.ast
+++ b/docs/contributing/ast/python3_0.ast
@@ -1,0 +1,147 @@
+-- Python 3.0 AST
+-- ASDL's four builtin types are identifier, int, string, object
+
+module Python version "3.0"
+{
+    mod = Module(stmt* body)
+        | Interactive(stmt* body)
+        | Expression(expr body)
+
+        -- not really an actual node but useful in Jython's typesystem.
+        | Suite(stmt* body)
+
+    stmt = FunctionDef(identifier name, arguments args,
+                       stmt* body, expr* decorator_list, expr? returns)
+         | ClassDef(identifier name,
+                    expr* bases,
+                    keyword* keywords,
+                    expr? starargs,
+                    expr? kwargs,
+                    stmt* body,
+                    expr *decorator_list)
+         | Return(expr? value)
+
+         | Delete(expr* targets)
+         | Assign(expr* targets, expr value)
+         | AugAssign(expr target, operator op, expr value)
+
+         -- use 'orelse' because else is a keyword in target languages
+         | For(expr target, expr iter, stmt* body, stmt* orelse)
+         | While(expr test, stmt* body, stmt* orelse)
+         | If(expr test, stmt* body, stmt* orelse)
+         | With(expr context_expr, expr? optional_vars, stmt* body)
+
+         | Raise(expr? exc, expr? cause)
+         | TryExcept(stmt* body, excepthandler* handlers, stmt* orelse)
+         | TryFinally(stmt* body, stmt* finalbody)
+         | Assert(expr test, expr? msg)
+
+         | Import(alias* names)
+         | ImportFrom(identifier module, alias* names, int? level)
+
+         | Global(identifier* names)
+         | Nonlocal(identifier* names)
+         | Expr(expr value)
+         | Pass | Break | Continue
+
+         -- XXX Jython will be different
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
+
+         -- BoolOp() can use left & right?
+    expr = BoolOp(boolop op, expr* values)
+         | BinOp(expr left, operator op, expr right)
+         | UnaryOp(unaryop op, expr operand)
+         | Lambda(arguments args, expr body)
+         | IfExp(expr test, expr body, expr orelse)
+         | Dict(expr* keys, expr* values)
+         | Set(expr* elts)
+         | ListComp(expr elt, comprehension* generators)
+         | SetComp(expr elt, comprehension* generators)
+         | DictComp(expr key, expr value, comprehension* generators)
+         | GeneratorExp(expr elt, comprehension* generators)
+         -- the grammar constrains where yield expressions can occur
+         | Yield(expr? value)
+         -- need sequences for compare to distinguish between
+         -- x < 4 < 3 and (x < 4) < 3
+         | Compare(expr left, cmpop* ops, expr* comparators)
+         | Call(expr func, expr* args, keyword* keywords,
+                expr? starargs, expr? kwargs)
+         | Num(object n) -- a number as a PyObject.
+         | Str(string s) -- need to specify raw, unicode, etc?
+         | Bytes(string s)
+         | Ellipsis
+         -- other literals? bools?
+
+         -- the following expression can appear in assignment context
+         | Attribute(expr value, identifier attr, expr_context ctx)
+         | Subscript(expr value, slice slice, expr_context ctx)
+         | Starred(expr value, expr_context ctx)
+         | Name(identifier id, expr_context ctx)
+         | List(expr* elts, expr_context ctx)
+         | Tuple(expr* elts, expr_context ctx)
+
+          -- col_offset is the byte offset in the utf8 string the parser uses
+          attributes (int lineno, int col_offset)
+
+    expr_context = Load
+                 | Store
+                 | Del
+                 | AugLoad
+                 | AugStore
+                 | Param
+
+    slice = Slice(expr? lower, expr? upper, expr? step)
+          | ExtSlice(slice* dims)
+          | Index(expr value)
+
+    boolop = And
+           | Or
+
+    operator = Add
+             | Sub
+             | Mult
+             | Div
+             | Mod
+             | Pow
+             | LShift
+             | RShift
+             | BitOr
+             | BitXor
+             | BitAnd
+             | FloorDiv
+
+    unaryop = Invert
+            | Not
+            | UAdd
+            | USub
+
+    cmpop = Eq
+          | NotEq
+          | Lt
+          | LtE
+          | Gt
+          | GtE
+          | Is
+          | IsNot
+          | In
+          | NotIn
+
+    comprehension = (expr target, expr iter, expr* ifs)
+
+    -- not sure what to call the first argument for raise and except
+    excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
+                    attributes (int lineno, int col_offset)
+
+    arguments = (arg* args, identifier? vararg, expr? varargannotation,
+                       arg* kwonlyargs, identifier? kwarg,
+                       expr? kwargannotation, expr* defaults,
+                       expr* kw_defaults)
+    arg = (identifier arg, expr? annotation)
+
+    -- keyword arguments supplied to call
+    keyword = (identifier arg, expr value)
+
+    -- import name with optional 'as' alias.
+    alias = (identifier name, identifier? asname)
+}

--- a/docs/contributing/ast/python3_0.ast
+++ b/docs/contributing/ast/python3_0.ast
@@ -10,8 +10,11 @@ module Python version "3.0"
         -- not really an actual node but useful in Jython's typesystem.
         | Suite(stmt* body)
 
-    stmt = FunctionDef(identifier name, arguments args,
-                       stmt* body, expr* decorator_list, expr? returns)
+    stmt = FunctionDef(identifier name,
+                       arguments args,
+                       stmt* body,
+                       expr* decorator_list,
+                       expr? returns)
          | ClassDef(identifier name,
                     expr* bases,
                     keyword* keywords,
@@ -42,7 +45,9 @@ module Python version "3.0"
          | Global(identifier* names)
          | Nonlocal(identifier* names)
          | Expr(expr value)
-         | Pass | Break | Continue
+         | Pass
+         | Break
+         | Continue
 
          -- XXX Jython will be different
          -- col_offset is the byte offset in the utf8 string the parser uses
@@ -65,8 +70,11 @@ module Python version "3.0"
          -- need sequences for compare to distinguish between
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
-         | Call(expr func, expr* args, keyword* keywords,
-                expr? starargs, expr? kwargs)
+         | Call(expr func,
+                expr* args,
+                keyword* keywords,
+                expr? starargs,
+                expr? kwargs)
          | Num(object n) -- a number as a PyObject.
          | Str(string s) -- need to specify raw, unicode, etc?
          | Bytes(string s)
@@ -81,8 +89,8 @@ module Python version "3.0"
          | List(expr* elts, expr_context ctx)
          | Tuple(expr* elts, expr_context ctx)
 
-          -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset)
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
 
     expr_context = Load
                  | Store
@@ -133,10 +141,14 @@ module Python version "3.0"
     excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
                     attributes (int lineno, int col_offset)
 
-    arguments = (arg* args, identifier? vararg, expr? varargannotation,
-                       arg* kwonlyargs, identifier? kwarg,
-                       expr? kwargannotation, expr* defaults,
-                       expr* kw_defaults)
+    arguments = (arg* args,
+                 identifier? vararg,
+                 expr? varargannotation,
+                 arg* kwonlyargs,
+                 identifier? kwarg,
+                 expr? kwargannotation,
+                 expr* defaults,
+                 expr* kw_defaults)
     arg = (identifier arg, expr? annotation)
 
     -- keyword arguments supplied to call

--- a/docs/contributing/ast/python3_1.ast
+++ b/docs/contributing/ast/python3_1.ast
@@ -1,0 +1,149 @@
+-- Python 3.1 AST
+-- ASDL's four builtin types are identifier, int, string, object
+
+module Python version "3.1"
+{
+    mod = Module(stmt* body)
+        | Interactive(stmt* body)
+        | Expression(expr body)
+
+        -- not really an actual node but useful in Jython's typesystem.
+        | Suite(stmt* body)
+
+    stmt = FunctionDef(identifier name, arguments args,
+                       stmt* body, expr* decorator_list, expr? returns)
+         | ClassDef(identifier name,
+                    expr* bases,
+                    keyword* keywords,
+                    expr? starargs,
+                    expr? kwargs,
+                    stmt* body,
+                    expr *decorator_list)
+         | Return(expr? value)
+
+         | Delete(expr* targets)
+         | Assign(expr* targets, expr value)
+         | AugAssign(expr target, operator op, expr value)
+
+         -- use 'orelse' because else is a keyword in target languages
+         | For(expr target, expr iter, stmt* body, stmt* orelse)
+         | While(expr test, stmt* body, stmt* orelse)
+         | If(expr test, stmt* body, stmt* orelse)
+         | With(expr context_expr, expr? optional_vars, stmt* body)
+
+         | Raise(expr? exc, expr? cause)
+         | TryExcept(stmt* body, excepthandler* handlers, stmt* orelse)
+         | TryFinally(stmt* body, stmt* finalbody)
+         | Assert(expr test, expr? msg)
+
+         | Import(alias* names)
+         | ImportFrom(identifier module, alias* names, int? level)
+
+         | Global(identifier* names)
+         | Nonlocal(identifier* names)
+         | Expr(expr value)
+         | Pass
+         | Break
+         | Continue
+
+         -- XXX Jython will be different
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
+
+         -- BoolOp() can use left & right?
+    expr = BoolOp(boolop op, expr* values)
+         | BinOp(expr left, operator op, expr right)
+         | UnaryOp(unaryop op, expr operand)
+         | Lambda(arguments args, expr body)
+         | IfExp(expr test, expr body, expr orelse)
+         | Dict(expr* keys, expr* values)
+         | Set(expr* elts)
+         | ListComp(expr elt, comprehension* generators)
+         | SetComp(expr elt, comprehension* generators)
+         | DictComp(expr key, expr value, comprehension* generators)
+         | GeneratorExp(expr elt, comprehension* generators)
+         -- the grammar constrains where yield expressions can occur
+         | Yield(expr? value)
+         -- need sequences for compare to distinguish between
+         -- x < 4 < 3 and (x < 4) < 3
+         | Compare(expr left, cmpop* ops, expr* comparators)
+         | Call(expr func, expr* args, keyword* keywords,
+                expr? starargs, expr? kwargs)
+         | Num(object n) -- a number as a PyObject.
+         | Str(string s) -- need to specify raw, unicode, etc?
+         | Bytes(string s)
+         | Ellipsis
+         -- other literals? bools?
+
+         -- the following expression can appear in assignment context
+         | Attribute(expr value, identifier attr, expr_context ctx)
+         | Subscript(expr value, slice slice, expr_context ctx)
+         | Starred(expr value, expr_context ctx)
+         | Name(identifier id, expr_context ctx)
+         | List(expr* elts, expr_context ctx)
+         | Tuple(expr* elts, expr_context ctx)
+
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
+
+    expr_context = Load
+                 | Store
+                 | Del
+                 | AugLoad
+                 | AugStore
+                 | Param
+
+    slice = Slice(expr? lower, expr? upper, expr? step)
+          | ExtSlice(slice* dims)
+          | Index(expr value)
+
+    boolop = And
+           | Or
+
+    operator = Add
+             | Sub
+             | Mult
+             | Div
+             | Mod
+             | Pow
+             | LShift
+             | RShift
+             | BitOr
+             | BitXor
+             | BitAnd
+             | FloorDiv
+
+    unaryop = Invert
+            | Not
+            | UAdd
+            | USub
+
+    cmpop = Eq
+          | NotEq
+          | Lt
+          | LtE
+          | Gt
+          | GtE
+          | Is
+          | IsNot
+          | In
+          | NotIn
+
+    comprehension = (expr target, expr iter, expr* ifs)
+
+    -- not sure what to call the first argument for raise and except
+    excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
+                    attributes (int lineno, int col_offset)
+
+    arguments = (arg* args, identifier? vararg, expr? varargannotation,
+                 arg* kwonlyargs, identifier? kwarg,
+                 expr? kwargannotation, expr* defaults,
+                 expr* kw_defaults)
+    arg = (identifier arg, expr? annotation)
+
+    -- keyword arguments supplied to call
+    keyword = (identifier arg, expr value)
+
+    -- import name with optional 'as' alias.
+    alias = (identifier name, identifier? asname)
+}

--- a/docs/contributing/ast/python3_1.ast
+++ b/docs/contributing/ast/python3_1.ast
@@ -10,8 +10,11 @@ module Python version "3.1"
         -- not really an actual node but useful in Jython's typesystem.
         | Suite(stmt* body)
 
-    stmt = FunctionDef(identifier name, arguments args,
-                       stmt* body, expr* decorator_list, expr? returns)
+    stmt = FunctionDef(identifier name,
+                       arguments args,
+                       stmt* body,
+                       expr* decorator_list,
+                       expr? returns)
          | ClassDef(identifier name,
                     expr* bases,
                     keyword* keywords,
@@ -67,8 +70,11 @@ module Python version "3.1"
          -- need sequences for compare to distinguish between
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
-         | Call(expr func, expr* args, keyword* keywords,
-                expr? starargs, expr? kwargs)
+         | Call(expr func,
+                expr* args,
+                keyword* keywords,
+                expr? starargs,
+                expr? kwargs)
          | Num(object n) -- a number as a PyObject.
          | Str(string s) -- need to specify raw, unicode, etc?
          | Bytes(string s)
@@ -135,9 +141,13 @@ module Python version "3.1"
     excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
                     attributes (int lineno, int col_offset)
 
-    arguments = (arg* args, identifier? vararg, expr? varargannotation,
-                 arg* kwonlyargs, identifier? kwarg,
-                 expr? kwargannotation, expr* defaults,
+    arguments = (arg* args,
+                 identifier? vararg,
+                 expr? varargannotation,
+                 arg* kwonlyargs,
+                 identifier? kwarg,
+                 expr? kwargannotation,
+                 expr* defaults,
                  expr* kw_defaults)
     arg = (identifier arg, expr? annotation)
 

--- a/docs/contributing/ast/python3_2.ast
+++ b/docs/contributing/ast/python3_2.ast
@@ -1,0 +1,146 @@
+-- Python 3.2 AST
+-- ASDL's four builtin types are identifier, int, string, object
+
+module Python version "3.2"
+{
+    mod = Module(stmt* body)
+        | Interactive(stmt* body)
+        | Expression(expr body)
+
+        -- not really an actual node but useful in Jython's typesystem.
+        | Suite(stmt* body)
+
+    stmt = FunctionDef(identifier name,
+                       arguments args,
+                       stmt* body,
+                       expr* decorator_list,
+                       expr? returns)
+         | ClassDef(identifier name,
+                    expr* bases,
+                    keyword* keywords,
+                    expr? starargs,
+                    expr? kwargs,
+                    stmt* body,
+                    expr* decorator_list)
+         | Return(expr? value)
+
+         | Delete(expr* targets)
+         | Assign(expr* targets, expr value)
+         | AugAssign(expr target, operator op, expr value)
+
+         -- use 'orelse' because else is a keyword in target languages
+         | For(expr target, expr iter, stmt* body, stmt* orelse)
+         | While(expr test, stmt* body, stmt* orelse)
+         | If(expr test, stmt* body, stmt* orelse)
+         | With(expr context_expr, expr? optional_vars, stmt* body)
+
+         | Raise(expr? exc, expr? cause)
+         | TryExcept(stmt* body, excepthandler* handlers, stmt* orelse)
+         | TryFinally(stmt* body, stmt* finalbody)
+         | Assert(expr test, expr? msg)
+
+         | Import(alias* names)
+         | ImportFrom(identifier? module, alias* names, int? level)
+
+         | Global(identifier* names)
+         | Nonlocal(identifier* names)
+         | Expr(expr value)
+         | Pass
+         | Break
+         | Continue
+
+         -- XXX Jython will be different
+         -- col_offset is the byte offset in the utf8 string the parser uses
+            attributes (int lineno, int col_offset)
+
+         -- BoolOp() can use left & right?
+    expr = BoolOp(boolop op, expr* values)
+         | BinOp(expr left, operator op, expr right)
+         | UnaryOp(unaryop op, expr operand)
+         | Lambda(arguments args, expr body)
+         | IfExp(expr test, expr body, expr orelse)
+         | Dict(expr* keys, expr* values)
+         | Set(expr* elts)
+         | ListComp(expr elt, comprehension* generators)
+         | SetComp(expr elt, comprehension* generators)
+         | DictComp(expr key, expr value, comprehension* generators)
+         | GeneratorExp(expr elt, comprehension* generators)
+         -- the grammar constrains where yield expressions can occur
+         | Yield(expr? value)
+         -- need sequences for compare to distinguish between
+         -- x < 4 < 3 and (x < 4) < 3
+         | Compare(expr left, cmpop* ops, expr* comparators)
+         | Call(expr func, expr* args, keyword* keywords,
+                expr? starargs, expr? kwargs)
+         | Num(object n) -- a number as a PyObject.
+         | Str(string s) -- need to specify raw, unicode, etc?
+         | Bytes(string s)
+         | Ellipsis
+         -- other literals? bools?
+
+         -- the following expression can appear in assignment context
+         | Attribute(expr value, identifier attr, expr_context ctx)
+         | Subscript(expr value, slice slice, expr_context ctx)
+         | Starred(expr value, expr_context ctx)
+         | Name(identifier id, expr_context ctx)
+         | List(expr* elts, expr_context ctx)
+         | Tuple(expr* elts, expr_context ctx)
+
+         -- col_offset is the byte offset in the utf8 string the parser uses
+            attributes (int lineno, int col_offset)
+
+    expr_context = Load | Store | Del | AugLoad | AugStore | Param
+
+    slice = Slice(expr? lower, expr? upper, expr? step)
+          | ExtSlice(slice* dims)
+          | Index(expr value)
+
+    boolop = And | Or
+
+    operator = Add
+             | Sub
+             | Mult
+             | Div
+             | Mod
+             | Pow
+             | LShift
+             | RShift
+             | BitOr
+             | BitXor
+             | BitAnd
+             | FloorDiv
+
+    unaryop = Invert
+            | Not
+            | UAdd
+            | USub
+
+    cmpop = Eq
+          | NotEq
+          | Lt
+          | LtE
+          | Gt
+          | GtE
+          | Is
+          | IsNot
+          | In
+          | NotIn
+
+    comprehension = (expr target, expr iter, expr* ifs)
+
+    -- not sure what to call the first argument for raise and except
+    excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
+                    attributes (int lineno, int col_offset)
+
+    arguments = (arg* args, identifier? vararg, expr? varargannotation,
+                       arg* kwonlyargs, identifier? kwarg,
+                       expr? kwargannotation, expr* defaults,
+                       expr* kw_defaults)
+    arg = (identifier arg, expr? annotation)
+
+    -- keyword arguments supplied to call
+    keyword = (identifier arg, expr value)
+
+    -- import name with optional 'as' alias.
+    alias = (identifier name, identifier? asname)
+}

--- a/docs/contributing/ast/python3_2.ast
+++ b/docs/contributing/ast/python3_2.ast
@@ -51,7 +51,7 @@ module Python version "3.2"
 
          -- XXX Jython will be different
          -- col_offset is the byte offset in the utf8 string the parser uses
-            attributes (int lineno, int col_offset)
+         attributes (int lineno, int col_offset)
 
          -- BoolOp() can use left & right?
     expr = BoolOp(boolop op, expr* values)
@@ -70,8 +70,11 @@ module Python version "3.2"
          -- need sequences for compare to distinguish between
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
-         | Call(expr func, expr* args, keyword* keywords,
-                expr? starargs, expr? kwargs)
+         | Call(expr func,
+                expr* args,
+                keyword* keywords,
+                expr? starargs,
+                expr? kwargs)
          | Num(object n) -- a number as a PyObject.
          | Str(string s) -- need to specify raw, unicode, etc?
          | Bytes(string s)
@@ -87,15 +90,21 @@ module Python version "3.2"
          | Tuple(expr* elts, expr_context ctx)
 
          -- col_offset is the byte offset in the utf8 string the parser uses
-            attributes (int lineno, int col_offset)
+         attributes (int lineno, int col_offset)
 
-    expr_context = Load | Store | Del | AugLoad | AugStore | Param
+    expr_context = Load
+                 | Store
+                 | Del
+                 | AugLoad
+                 | AugStore
+                 | Param
 
     slice = Slice(expr? lower, expr? upper, expr? step)
           | ExtSlice(slice* dims)
           | Index(expr value)
 
-    boolop = And | Or
+    boolop = And
+           | Or
 
     operator = Add
              | Sub
@@ -132,10 +141,14 @@ module Python version "3.2"
     excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
                     attributes (int lineno, int col_offset)
 
-    arguments = (arg* args, identifier? vararg, expr? varargannotation,
-                       arg* kwonlyargs, identifier? kwarg,
-                       expr? kwargannotation, expr* defaults,
-                       expr* kw_defaults)
+    arguments = (arg* args,
+                 identifier? vararg,
+                 expr? varargannotation,
+                 arg* kwonlyargs,
+                 identifier? kwarg,
+                 expr? kwargannotation,
+                 expr* defaults,
+                 expr* kw_defaults)
     arg = (identifier arg, expr? annotation)
 
     -- keyword arguments supplied to call

--- a/docs/contributing/ast/python3_3.ast
+++ b/docs/contributing/ast/python3_3.ast
@@ -1,0 +1,155 @@
+-- PYTHON 3.3 AST
+-- ASDL's five builtin types are identifier, int, string, bytes, object
+
+module Python version "3.3"
+{
+    mod = Module(stmt* body)
+        | Interactive(stmt* body)
+        | Expression(expr body)
+
+        -- not really an actual node but useful in Jython's typesystem.
+        | Suite(stmt* body)
+
+    stmt = FunctionDef(identifier name,
+                       arguments args,
+                       stmt* body,
+                       expr* decorator_list,
+                       expr? returns)
+         | ClassDef(identifier name,
+                    expr* bases,
+                    keyword* keywords,
+                    expr? starargs,
+                    expr? kwargs,
+                    stmt* body,
+                    expr* decorator_list)
+         | Return(expr? value)
+
+         | Delete(expr* targets)
+         | Assign(expr* targets, expr value)
+         | AugAssign(expr target, operator op, expr value)
+
+         -- use 'orelse' because else is a keyword in target languages
+         | For(expr target, expr iter, stmt* body, stmt* orelse)
+         | While(expr test, stmt* body, stmt* orelse)
+         | If(expr test, stmt* body, stmt* orelse)
+         | With(withitem* items, stmt* body)
+
+         | Raise(expr? exc, expr? cause)
+         | Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
+         | Assert(expr test, expr? msg)
+
+         | Import(alias* names)
+         | ImportFrom(identifier? module, alias* names, int? level)
+
+         | Global(identifier* names)
+         | Nonlocal(identifier* names)
+         | Expr(expr value)
+         | Pass | Break | Continue
+
+         -- XXX Jython will be different
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
+
+         -- BoolOp() can use left & right?
+    expr = BoolOp(boolop op, expr* values)
+         | BinOp(expr left, operator op, expr right)
+         | UnaryOp(unaryop op, expr operand)
+         | Lambda(arguments args, expr body)
+         | IfExp(expr test, expr body, expr orelse)
+         | Dict(expr* keys, expr* values)
+         | Set(expr* elts)
+         | ListComp(expr elt, comprehension* generators)
+         | SetComp(expr elt, comprehension* generators)
+         | DictComp(expr key, expr value, comprehension* generators)
+         | GeneratorExp(expr elt, comprehension* generators)
+         -- the grammar constrains where yield expressions can occur
+         | Yield(expr? value)
+         | YieldFrom(expr value)
+         -- need sequences for compare to distinguish between
+         -- x < 4 < 3 and (x < 4) < 3
+         | Compare(expr left, cmpop* ops, expr* comparators)
+         | Call(expr func, expr* args, keyword* keywords,
+             expr? starargs, expr? kwargs)
+         | Num(object n) -- a number as a PyObject.
+         | Str(string s) -- need to specify raw, unicode, etc?
+         | Bytes(bytes s)
+         | Ellipsis
+         -- other literals? bools?
+
+         -- the following expression can appear in assignment context
+         | Attribute(expr value, identifier attr, expr_context ctx)
+         | Subscript(expr value, slice slice, expr_context ctx)
+         | Starred(expr value, expr_context ctx)
+         | Name(identifier id, expr_context ctx)
+         | List(expr* elts, expr_context ctx)
+         | Tuple(expr* elts, expr_context ctx)
+
+          -- col_offset is the byte offset in the utf8 string the parser uses
+          attributes (int lineno, int col_offset)
+
+    expr_context = Load
+                 | Store
+                 | Del
+                 | AugLoad
+                 | AugStore
+                 | Param
+
+    slice = Slice(expr? lower, expr? upper, expr? step)
+          | ExtSlice(slice* dims)
+          | Index(expr value)
+
+    boolop = And
+           | Or
+
+    operator = Add
+             | Sub
+             | Mult
+             | Div
+             | Mod
+             | Pow
+             | LShift
+             | RShift
+             | BitOr
+             | BitXor
+             | BitAnd
+             | FloorDiv
+
+    unaryop = Invert
+            | Not
+            | UAdd
+            | USub
+
+    cmpop = Eq
+          | NotEq
+          | Lt
+          | LtE
+          | Gt
+          | GtE
+          | Is
+          | IsNot
+          | In
+          | NotIn
+
+    comprehension = (expr target, expr iter, expr* ifs)
+
+    excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
+                    attributes (int lineno, int col_offset)
+
+    arguments = (arg* args,
+                 identifier? vararg,
+                 expr? varargannotation,
+                 arg* kwonlyargs,
+                 identifier? kwarg,
+                 expr? kwargannotation,
+                 expr* defaults,
+                 expr* kw_defaults)
+    arg = (identifier arg, expr? annotation)
+
+    -- keyword arguments supplied to call
+    keyword = (identifier arg, expr value)
+
+    -- import name with optional 'as' alias.
+    alias = (identifier name, identifier? asname)
+
+    withitem = (expr context_expr, expr? optional_vars)
+}

--- a/docs/contributing/ast/python3_3.ast
+++ b/docs/contributing/ast/python3_3.ast
@@ -44,7 +44,9 @@ module Python version "3.3"
          | Global(identifier* names)
          | Nonlocal(identifier* names)
          | Expr(expr value)
-         | Pass | Break | Continue
+         | Pass
+         | Break
+         | Continue
 
          -- XXX Jython will be different
          -- col_offset is the byte offset in the utf8 string the parser uses
@@ -68,8 +70,11 @@ module Python version "3.3"
          -- need sequences for compare to distinguish between
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
-         | Call(expr func, expr* args, keyword* keywords,
-             expr? starargs, expr? kwargs)
+         | Call(expr func,
+                expr* args,
+                keyword* keywords,
+                expr? starargs,
+                expr? kwargs)
          | Num(object n) -- a number as a PyObject.
          | Str(string s) -- need to specify raw, unicode, etc?
          | Bytes(bytes s)
@@ -84,8 +89,8 @@ module Python version "3.3"
          | List(expr* elts, expr_context ctx)
          | Tuple(expr* elts, expr_context ctx)
 
-          -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset)
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
 
     expr_context = Load
                  | Store

--- a/docs/contributing/ast/python3_4.ast
+++ b/docs/contributing/ast/python3_4.ast
@@ -1,0 +1,156 @@
+-- Python 3.4 AST
+-- ASDL's six builtin types are identifier, int, string, bytes, object, singleton
+
+module Python version "3.4"
+{
+    mod = Module(stmt* body)
+        | Interactive(stmt* body)
+        | Expression(expr body)
+
+        -- not really an actual node but useful in Jython's typesystem.
+        | Suite(stmt* body)
+
+    stmt = FunctionDef(identifier name,
+                       arguments args,
+                       stmt* body,
+                       expr* decorator_list,
+                       expr? returns)
+         | ClassDef(identifier name,
+                    expr* bases,
+                    keyword* keywords,
+                    expr? starargs,
+                    expr? kwargs,
+                    stmt* body,
+                    expr* decorator_list)
+         | Return(expr? value)
+
+         | Delete(expr* targets)
+         | Assign(expr* targets, expr value)
+         | AugAssign(expr target, operator op, expr value)
+
+         -- use 'orelse' because else is a keyword in target languages
+         | For(expr target, expr iter, stmt* body, stmt* orelse)
+         | While(expr test, stmt* body, stmt* orelse)
+         | If(expr test, stmt* body, stmt* orelse)
+         | With(withitem* items, stmt* body)
+
+         | Raise(expr? exc, expr? cause)
+         | Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
+         | Assert(expr test, expr? msg)
+
+         | Import(alias* names)
+         | ImportFrom(identifier? module, alias* names, int? level)
+
+         | Global(identifier* names)
+         | Nonlocal(identifier* names)
+         | Expr(expr value)
+         | Pass
+         | Break
+         | Continue
+
+          -- XXX Jython will be different
+          -- col_offset is the byte offset in the utf8 string the parser uses
+          attributes (int lineno, int col_offset)
+
+          -- BoolOp() can use left & right?
+    expr = BoolOp(boolop op, expr* values)
+         | BinOp(expr left, operator op, expr right)
+         | UnaryOp(unaryop op, expr operand)
+         | Lambda(arguments args, expr body)
+         | IfExp(expr test, expr body, expr orelse)
+         | Dict(expr* keys, expr* values)
+         | Set(expr* elts)
+         | ListComp(expr elt, comprehension* generators)
+         | SetComp(expr elt, comprehension* generators)
+         | DictComp(expr key, expr value, comprehension* generators)
+         | GeneratorExp(expr elt, comprehension* generators)
+         -- the grammar constrains where yield expressions can occur
+         | Yield(expr? value)
+         | YieldFrom(expr value)
+         -- need sequences for compare to distinguish between
+         -- x < 4 < 3 and (x < 4) < 3
+         | Compare(expr left, cmpop* ops, expr* comparators)
+         | Call(expr func, expr* args, keyword* keywords,
+                expr? starargs, expr? kwargs)
+         | Num(object n) -- a number as a PyObject.
+         | Str(string s) -- need to specify raw, unicode, etc?
+         | Bytes(bytes s)
+         | NameConstant(singleton value)
+         | Ellipsis
+
+         -- the following expression can appear in assignment context
+         | Attribute(expr value, identifier attr, expr_context ctx)
+         | Subscript(expr value, slice slice, expr_context ctx)
+         | Starred(expr value, expr_context ctx)
+         | Name(identifier id, expr_context ctx)
+         | List(expr* elts, expr_context ctx)
+         | Tuple(expr* elts, expr_context ctx)
+
+          -- col_offset is the byte offset in the utf8 string the parser uses
+          attributes (int lineno, int col_offset)
+
+    expr_context = Load
+                 | Store
+                 | Del
+                 | AugLoad
+                 | AugStore
+                 | Param
+
+    slice = Slice(expr? lower, expr? upper, expr? step)
+          | ExtSlice(slice* dims)
+          | Index(expr value)
+
+    boolop = And
+           | Or
+
+    operator = Add
+             | Sub
+             | Mult
+             | Div
+             | Mod
+             | Pow
+             | LShift
+             | RShift
+             | BitOr
+             | BitXor
+             | BitAnd
+             | FloorDiv
+
+    unaryop = Invert
+            | Not
+            | UAdd
+            | USub
+
+    cmpop = Eq
+          | NotEq
+          | Lt
+          | LtE
+          | Gt
+          | GtE
+          | Is
+          | IsNot
+          | In
+          | NotIn
+
+    comprehension = (expr target, expr iter, expr* ifs)
+
+    excepthandler = ExceptHandler(expr? type,
+                                  identifier? name,
+                                  stmt* body)
+                    attributes (int lineno,
+                                int col_offset)
+
+    arguments = (arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults,
+                 arg? kwarg, expr* defaults)
+
+    arg = (identifier arg, expr? annotation)
+           attributes (int lineno, int col_offset)
+
+    -- keyword arguments supplied to call
+    keyword = (identifier arg, expr value)
+
+    -- import name with optional 'as' alias.
+    alias = (identifier name, identifier? asname)
+
+    withitem = (expr context_expr, expr? optional_vars)
+}

--- a/docs/contributing/ast/python3_4.ast
+++ b/docs/contributing/ast/python3_4.ast
@@ -48,11 +48,11 @@ module Python version "3.4"
          | Break
          | Continue
 
-          -- XXX Jython will be different
-          -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset)
+         -- XXX Jython will be different
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
 
-          -- BoolOp() can use left & right?
+         -- BoolOp() can use left & right?
     expr = BoolOp(boolop op, expr* values)
          | BinOp(expr left, operator op, expr right)
          | UnaryOp(unaryop op, expr operand)
@@ -70,8 +70,11 @@ module Python version "3.4"
          -- need sequences for compare to distinguish between
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
-         | Call(expr func, expr* args, keyword* keywords,
-                expr? starargs, expr? kwargs)
+         | Call(expr func,
+                expr* args,
+                keyword* keywords,
+                expr? starargs,
+                expr? kwargs)
          | Num(object n) -- a number as a PyObject.
          | Str(string s) -- need to specify raw, unicode, etc?
          | Bytes(bytes s)
@@ -86,8 +89,8 @@ module Python version "3.4"
          | List(expr* elts, expr_context ctx)
          | Tuple(expr* elts, expr_context ctx)
 
-          -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset)
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
 
     expr_context = Load
                  | Store
@@ -134,17 +137,18 @@ module Python version "3.4"
 
     comprehension = (expr target, expr iter, expr* ifs)
 
-    excepthandler = ExceptHandler(expr? type,
-                                  identifier? name,
-                                  stmt* body)
-                    attributes (int lineno,
-                                int col_offset)
+    excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
+                    attributes (int lineno, int col_offset)
 
-    arguments = (arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults,
-                 arg? kwarg, expr* defaults)
+    arguments = (arg* args,
+                 arg? vararg,
+                 arg* kwonlyargs,
+                 expr* kw_defaults,
+                 arg? kwarg,
+                 expr* defaults)
 
     arg = (identifier arg, expr? annotation)
-           attributes (int lineno, int col_offset)
+          attributes (int lineno, int col_offset)
 
     -- keyword arguments supplied to call
     keyword = (identifier arg, expr value)

--- a/docs/contributing/ast/python3_5.ast
+++ b/docs/contributing/ast/python3_5.ast
@@ -1,0 +1,152 @@
+-- Python 3.5 AST
+-- ASDL's six builtin types are identifier, int, string, bytes, object, singleton
+
+module Python version "3.5"
+{
+    mod = Module(stmt* body)
+        | Interactive(stmt* body)
+        | Expression(expr body)
+
+        -- not really an actual node but useful in Jython's typesystem.
+        | Suite(stmt* body)
+
+    stmt = FunctionDef(identifier name, arguments args,
+                       stmt* body, expr* decorator_list, expr? returns)
+         | AsyncFunctionDef(identifier name, arguments args,
+                            stmt* body, expr* decorator_list, expr? returns)
+
+         | ClassDef(identifier name,
+                    expr* bases,
+                    keyword* keywords,
+                    stmt* body,
+                    expr* decorator_list)
+         | Return(expr? value)
+
+         | Delete(expr* targets)
+         | Assign(expr* targets, expr value)
+         | AugAssign(expr target, operator op, expr value)
+
+         -- use 'orelse' because else is a keyword in target languages
+         | For(expr target, expr iter, stmt* body, stmt* orelse)
+         | AsyncFor(expr target, expr iter, stmt* body, stmt* orelse)
+         | While(expr test, stmt* body, stmt* orelse)
+         | If(expr test, stmt* body, stmt* orelse)
+         | With(withitem* items, stmt* body)
+         | AsyncWith(withitem* items, stmt* body)
+
+         | Raise(expr? exc, expr? cause)
+         | Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
+         | Assert(expr test, expr? msg)
+
+         | Import(alias* names)
+         | ImportFrom(identifier? module, alias* names, int? level)
+
+         | Global(identifier* names)
+         | Nonlocal(identifier* names)
+         | Expr(expr value)
+         | Pass | Break | Continue
+
+         -- XXX Jython will be different
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
+
+         -- BoolOp() can use left & right?
+    expr = BoolOp(boolop op, expr* values)
+         | BinOp(expr left, operator op, expr right)
+         | UnaryOp(unaryop op, expr operand)
+         | Lambda(arguments args, expr body)
+         | IfExp(expr test, expr body, expr orelse)
+         | Dict(expr* keys, expr* values)
+         | Set(expr* elts)
+         | ListComp(expr elt, comprehension* generators)
+         | SetComp(expr elt, comprehension* generators)
+         | DictComp(expr key, expr value, comprehension* generators)
+         | GeneratorExp(expr elt, comprehension* generators)
+         -- the grammar constrains where yield expressions can occur
+         | Await(expr value)
+         | Yield(expr? value)
+         | YieldFrom(expr value)
+         -- need sequences for compare to distinguish between
+         -- x < 4 < 3 and (x < 4) < 3
+         | Compare(expr left, cmpop* ops, expr* comparators)
+         | Call(expr func, expr* args, keyword* keywords)
+         | Num(object n) -- a number as a PyObject.
+         | Str(string s) -- need to specify raw, unicode, etc?
+         | Bytes(bytes s)
+         | NameConstant(singleton value)
+         | Ellipsis
+
+         -- the following expression can appear in assignment context
+         | Attribute(expr value, identifier attr, expr_context ctx)
+         | Subscript(expr value, slice slice, expr_context ctx)
+         | Starred(expr value, expr_context ctx)
+         | Name(identifier id, expr_context ctx)
+         | List(expr* elts, expr_context ctx)
+         | Tuple(expr* elts, expr_context ctx)
+
+          -- col_offset is the byte offset in the utf8 string the parser uses
+          attributes (int lineno, int col_offset)
+
+    expr_context = Load
+                 | Store
+                 | Del
+                 | AugLoad
+                 | AugStore
+                 | Param
+
+    slice = Slice(expr? lower, expr? upper, expr? step)
+          | ExtSlice(slice* dims)
+          | Index(expr value)
+
+    boolop = And
+           | Or
+
+    operator = Add
+             | Sub
+             | Mult
+             | MatMult
+             | Div
+             | Mod
+             | Pow
+             | LShift
+             | RShift
+             | BitOr
+             | BitXor
+             | BitAnd
+             | FloorDiv
+
+    unaryop = Invert
+            | Not
+            | UAdd
+            | USub
+
+    cmpop = Eq
+          | NotEq
+          | Lt
+          | LtE
+          | Gt
+          | GtE
+          | Is
+          | IsNot
+          | In
+          | NotIn
+
+    comprehension = (expr target, expr iter, expr* ifs)
+
+    excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
+                    attributes (int lineno, int col_offset)
+
+    arguments = (arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults,
+                 arg? kwarg, expr* defaults)
+
+    arg = (identifier arg, expr? annotation)
+           attributes (int lineno, int col_offset)
+
+    -- keyword arguments supplied to call (NULL identifier for **kwargs)
+    keyword = (identifier? arg, expr value)
+
+    -- import name with optional 'as' alias.
+    alias = (identifier name, identifier? asname)
+
+    withitem = (expr context_expr, expr? optional_vars)
+}

--- a/docs/contributing/ast/python3_5.ast
+++ b/docs/contributing/ast/python3_5.ast
@@ -10,10 +10,16 @@ module Python version "3.5"
         -- not really an actual node but useful in Jython's typesystem.
         | Suite(stmt* body)
 
-    stmt = FunctionDef(identifier name, arguments args,
-                       stmt* body, expr* decorator_list, expr? returns)
-         | AsyncFunctionDef(identifier name, arguments args,
-                            stmt* body, expr* decorator_list, expr? returns)
+    stmt = FunctionDef(identifier name,
+                       arguments args,
+                       stmt* body,
+                       expr* decorator_list,
+                       expr? returns)
+         | AsyncFunctionDef(identifier name,
+                            arguments args,
+                            stmt* body,
+                            expr* decorator_list,
+                            expr? returns)
 
          | ClassDef(identifier name,
                     expr* bases,
@@ -44,7 +50,9 @@ module Python version "3.5"
          | Global(identifier* names)
          | Nonlocal(identifier* names)
          | Expr(expr value)
-         | Pass | Break | Continue
+         | Pass
+         | Break
+         | Continue
 
          -- XXX Jython will be different
          -- col_offset is the byte offset in the utf8 string the parser uses
@@ -69,7 +77,9 @@ module Python version "3.5"
          -- need sequences for compare to distinguish between
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
-         | Call(expr func, expr* args, keyword* keywords)
+         | Call(expr func,
+                expr* args,
+                keyword* keywords)
          | Num(object n) -- a number as a PyObject.
          | Str(string s) -- need to specify raw, unicode, etc?
          | Bytes(bytes s)
@@ -84,8 +94,8 @@ module Python version "3.5"
          | List(expr* elts, expr_context ctx)
          | Tuple(expr* elts, expr_context ctx)
 
-          -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset)
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
 
     expr_context = Load
                  | Store
@@ -136,11 +146,15 @@ module Python version "3.5"
     excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
                     attributes (int lineno, int col_offset)
 
-    arguments = (arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults,
-                 arg? kwarg, expr* defaults)
+    arguments = (arg* args,
+                 arg? vararg,
+                 arg* kwonlyargs,
+                 expr* kw_defaults,
+                 arg? kwarg,
+                 expr* defaults)
 
     arg = (identifier arg, expr? annotation)
-           attributes (int lineno, int col_offset)
+          attributes (int lineno, int col_offset)
 
     -- keyword arguments supplied to call (NULL identifier for **kwargs)
     keyword = (identifier? arg, expr value)

--- a/docs/contributing/ast/python3_6.ast
+++ b/docs/contributing/ast/python3_6.ast
@@ -1,0 +1,169 @@
+-- Python 3.6 AST
+-- ASDL's 7 builtin types are:
+-- identifier, int, string, bytes, object, singleton, constant
+--
+-- singleton: None, True or False
+-- constant can be None, whereas None means "no value" for object.
+
+module Python version "3.6"
+{
+    mod = Module(stmt* body)
+        | Interactive(stmt* body)
+        | Expression(expr body)
+
+        -- not really an actual node but useful in Jython's typesystem.
+        | Suite(stmt* body)
+
+    stmt = FunctionDef(identifier name,
+                       arguments args,
+                       stmt* body,
+                       expr* decorator_list,
+                       expr? returns)
+         | AsyncFunctionDef(identifier name,
+                            arguments args,
+                            stmt* body,
+                            expr* decorator_list,
+                            expr? returns)
+
+         | ClassDef(identifier name,
+                    expr* bases,
+                    keyword* keywords,
+                    stmt* body,
+                    expr* decorator_list)
+         | Return(expr? value)
+
+         | Delete(expr* targets)
+         | Assign(expr* targets, expr value)
+         | AugAssign(expr target, operator op, expr value)
+         -- 'simple' indicates that we annotate simple name without parens
+         | AnnAssign(expr target, expr annotation, expr? value, int simple)
+
+         -- use 'orelse' because else is a keyword in target languages
+         | For(expr target, expr iter, stmt* body, stmt* orelse)
+         | AsyncFor(expr target, expr iter, stmt* body, stmt* orelse)
+         | While(expr test, stmt* body, stmt* orelse)
+         | If(expr test, stmt* body, stmt* orelse)
+         | With(withitem* items, stmt* body)
+         | AsyncWith(withitem* items, stmt* body)
+
+         | Raise(expr? exc, expr? cause)
+         | Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
+         | Assert(expr test, expr? msg)
+
+         | Import(alias* names)
+         | ImportFrom(identifier? module, alias* names, int? level)
+
+         | Global(identifier* names)
+         | Nonlocal(identifier* names)
+         | Expr(expr value)
+         | Pass
+         | Break
+         | Continue
+
+         -- XXX Jython will be different
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
+
+         -- BoolOp() can use left & right?
+    expr = BoolOp(boolop op, expr* values)
+         | BinOp(expr left, operator op, expr right)
+         | UnaryOp(unaryop op, expr operand)
+         | Lambda(arguments args, expr body)
+         | IfExp(expr test, expr body, expr orelse)
+         | Dict(expr* keys, expr* values)
+         | Set(expr* elts)
+         | ListComp(expr elt, comprehension* generators)
+         | SetComp(expr elt, comprehension* generators)
+         | DictComp(expr key, expr value, comprehension* generators)
+         | GeneratorExp(expr elt, comprehension* generators)
+         -- the grammar constrains where yield expressions can occur
+         | Await(expr value)
+         | Yield(expr? value)
+         | YieldFrom(expr value)
+         -- need sequences for compare to distinguish between
+         -- x < 4 < 3 and (x < 4) < 3
+         | Compare(expr left, cmpop* ops, expr* comparators)
+         | Call(expr func, expr* args, keyword* keywords)
+         | Num(object n) -- a number as a PyObject.
+         | Str(string s) -- need to specify raw, unicode, etc?
+         | FormattedValue(expr value, int? conversion, expr? format_spec)
+         | JoinedStr(expr* values)
+         | Bytes(bytes s)
+         | NameConstant(singleton value)
+         | Ellipsis
+         | Constant(constant value)
+
+         -- the following expression can appear in assignment context
+         | Attribute(expr value, identifier attr, expr_context ctx)
+         | Subscript(expr value, slice slice, expr_context ctx)
+         | Starred(expr value, expr_context ctx)
+         | Name(identifier id, expr_context ctx)
+         | List(expr* elts, expr_context ctx)
+         | Tuple(expr* elts, expr_context ctx)
+
+          -- col_offset is the byte offset in the utf8 string the parser uses
+          attributes (int lineno, int col_offset)
+
+    expr_context = Load
+                 | Store
+                 | Del
+                 | AugLoad
+                 | AugStore
+                 | Param
+
+    slice = Slice(expr? lower, expr? upper, expr? step)
+          | ExtSlice(slice* dims)
+          | Index(expr value)
+
+    boolop = And
+           | Or
+
+    operator = Add
+             | Sub
+             | Mult
+             | MatMult
+             | Div
+             | Mod
+             | Pow
+             | LShift
+             | RShift
+             | BitOr
+             | BitXor
+             | BitAnd
+             | FloorDiv
+
+    unaryop = Invert
+            | Not
+            | UAdd
+            | USub
+
+    cmpop = Eq
+          | NotEq
+          | Lt
+          | LtE
+          | Gt
+          | GtE
+          | Is
+          | IsNot
+          | In
+          | NotIn
+
+    comprehension = (expr target, expr iter, expr* ifs, int is_async)
+
+    excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
+                    attributes (int lineno, int col_offset)
+
+    arguments = (arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults,
+                 arg? kwarg, expr* defaults)
+
+    arg = (identifier arg, expr? annotation)
+           attributes (int lineno, int col_offset)
+
+    -- keyword arguments supplied to call (NULL identifier for **kwargs)
+    keyword = (identifier? arg, expr value)
+
+    -- import name with optional 'as' alias.
+    alias = (identifier name, identifier? asname)
+
+    withitem = (expr context_expr, expr? optional_vars)
+}

--- a/docs/contributing/ast/python3_6.ast
+++ b/docs/contributing/ast/python3_6.ast
@@ -83,7 +83,9 @@ module Python version "3.6"
          -- need sequences for compare to distinguish between
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
-         | Call(expr func, expr* args, keyword* keywords)
+         | Call(expr func,
+                expr* args,
+                keyword* keywords)
          | Num(object n) -- a number as a PyObject.
          | Str(string s) -- need to specify raw, unicode, etc?
          | FormattedValue(expr value, int? conversion, expr? format_spec)
@@ -101,8 +103,8 @@ module Python version "3.6"
          | List(expr* elts, expr_context ctx)
          | Tuple(expr* elts, expr_context ctx)
 
-          -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset)
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
 
     expr_context = Load
                  | Store
@@ -153,11 +155,15 @@ module Python version "3.6"
     excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
                     attributes (int lineno, int col_offset)
 
-    arguments = (arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults,
-                 arg? kwarg, expr* defaults)
+    arguments = (arg* args,
+                 arg? vararg,
+                 arg* kwonlyargs,
+                 expr* kw_defaults,
+                 arg? kwarg,
+                 expr* defaults)
 
     arg = (identifier arg, expr? annotation)
-           attributes (int lineno, int col_offset)
+          attributes (int lineno, int col_offset)
 
     -- keyword arguments supplied to call (NULL identifier for **kwargs)
     keyword = (identifier? arg, expr value)

--- a/docs/contributing/ast/python3_7.ast
+++ b/docs/contributing/ast/python3_7.ast
@@ -19,52 +19,52 @@ module Python version "3.7"
                        stmt* body,
                        expr* decorator_list,
                        expr? returns)
-          | AsyncFunctionDef(identifier name,
-                             arguments args,
-                             stmt* body,
-                             expr* decorator_list,
-                             expr? returns)
+         | AsyncFunctionDef(identifier name,
+                            arguments args,
+                            stmt* body,
+                            expr* decorator_list,
+                            expr? returns)
 
-          | ClassDef(identifier name,
-                     expr* bases,
-                     keyword* keywords,
-                     stmt* body,
-                     expr* decorator_list)
-          | Return(expr? value)
+         | ClassDef(identifier name,
+                    expr* bases,
+                    keyword* keywords,
+                    stmt* body,
+                    expr* decorator_list)
+         | Return(expr? value)
 
-          | Delete(expr* targets)
-          | Assign(expr* targets, expr value)
-          | AugAssign(expr target, operator op, expr value)
-          -- 'simple' indicates that we annotate simple name without parens
-          | AnnAssign(expr target, expr annotation, expr? value, int simple)
+         | Delete(expr* targets)
+         | Assign(expr* targets, expr value)
+         | AugAssign(expr target, operator op, expr value)
+         -- 'simple' indicates that we annotate simple name without parens
+         | AnnAssign(expr target, expr annotation, expr? value, int simple)
 
-          -- use 'orelse' because else is a keyword in target languages
-          | For(expr target, expr iter, stmt* body, stmt* orelse)
-          | AsyncFor(expr target, expr iter, stmt* body, stmt* orelse)
-          | While(expr test, stmt* body, stmt* orelse)
-          | If(expr test, stmt* body, stmt* orelse)
-          | With(withitem* items, stmt* body)
-          | AsyncWith(withitem* items, stmt* body)
+         -- use 'orelse' because else is a keyword in target languages
+         | For(expr target, expr iter, stmt* body, stmt* orelse)
+         | AsyncFor(expr target, expr iter, stmt* body, stmt* orelse)
+         | While(expr test, stmt* body, stmt* orelse)
+         | If(expr test, stmt* body, stmt* orelse)
+         | With(withitem* items, stmt* body)
+         | AsyncWith(withitem* items, stmt* body)
 
-          | Raise(expr? exc, expr? cause)
-          | Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
-          | Assert(expr test, expr? msg)
+         | Raise(expr? exc, expr? cause)
+         | Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
+         | Assert(expr test, expr? msg)
 
-          | Import(alias* names)
-          | ImportFrom(identifier? module, alias* names, int? level)
+         | Import(alias* names)
+         | ImportFrom(identifier? module, alias* names, int? level)
 
-          | Global(identifier* names)
-          | Nonlocal(identifier* names)
-          | Expr(expr value)
-          | Pass
-          | Break
-          | Continue
+         | Global(identifier* names)
+         | Nonlocal(identifier* names)
+         | Expr(expr value)
+         | Pass
+         | Break
+         | Continue
 
-          -- XXX Jython will be different
-          -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset)
+         -- XXX Jython will be different
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
 
-          -- BoolOp() can use left & right?
+         -- BoolOp() can use left & right?
     expr = BoolOp(boolop op, expr* values)
          | BinOp(expr left, operator op, expr right)
          | UnaryOp(unaryop op, expr operand)
@@ -83,7 +83,9 @@ module Python version "3.7"
          -- need sequences for compare to distinguish between
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
-         | Call(expr func, expr* args, keyword* keywords)
+         | Call(expr func,
+                expr* args,
+                keyword* keywords)
          | Num(object n) -- a number as a PyObject.
          | Str(string s) -- need to specify raw, unicode, etc?
          | FormattedValue(expr value, int? conversion, expr? format_spec)
@@ -101,8 +103,8 @@ module Python version "3.7"
          | List(expr* elts, expr_context ctx)
          | Tuple(expr* elts, expr_context ctx)
 
-          -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset)
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset)
 
     expr_context = Load
                  | Store
@@ -153,11 +155,15 @@ module Python version "3.7"
     excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
                     attributes (int lineno, int col_offset)
 
-    arguments = (arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults,
-                 arg? kwarg, expr* defaults)
+    arguments = (arg* args,
+                 arg? vararg,
+                 arg* kwonlyargs,
+                 expr* kw_defaults,
+                 arg? kwarg,
+                 expr* defaults)
 
     arg = (identifier arg, expr? annotation)
-           attributes (int lineno, int col_offset)
+          attributes (int lineno, int col_offset)
 
     -- keyword arguments supplied to call (NULL identifier for **kwargs)
     keyword = (identifier? arg, expr value)

--- a/docs/contributing/ast/python3_7.ast
+++ b/docs/contributing/ast/python3_7.ast
@@ -1,0 +1,169 @@
+-- Python 3.7 AST
+-- ASDL's 7 builtin types are:
+-- identifier, int, string, bytes, object, singleton, constant
+--
+-- singleton: None, True or False
+-- constant can be None, whereas None means "no value" for object.
+
+module Python version "3.7"
+{
+    mod = Module(stmt* body)
+        | Interactive(stmt* body)
+        | Expression(expr body)
+
+        -- not really an actual node but useful in Jython's typesystem.
+        | Suite(stmt* body)
+
+    stmt = FunctionDef(identifier name,
+                       arguments args,
+                       stmt* body,
+                       expr* decorator_list,
+                       expr? returns)
+          | AsyncFunctionDef(identifier name,
+                             arguments args,
+                             stmt* body,
+                             expr* decorator_list,
+                             expr? returns)
+
+          | ClassDef(identifier name,
+                     expr* bases,
+                     keyword* keywords,
+                     stmt* body,
+                     expr* decorator_list)
+          | Return(expr? value)
+
+          | Delete(expr* targets)
+          | Assign(expr* targets, expr value)
+          | AugAssign(expr target, operator op, expr value)
+          -- 'simple' indicates that we annotate simple name without parens
+          | AnnAssign(expr target, expr annotation, expr? value, int simple)
+
+          -- use 'orelse' because else is a keyword in target languages
+          | For(expr target, expr iter, stmt* body, stmt* orelse)
+          | AsyncFor(expr target, expr iter, stmt* body, stmt* orelse)
+          | While(expr test, stmt* body, stmt* orelse)
+          | If(expr test, stmt* body, stmt* orelse)
+          | With(withitem* items, stmt* body)
+          | AsyncWith(withitem* items, stmt* body)
+
+          | Raise(expr? exc, expr? cause)
+          | Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
+          | Assert(expr test, expr? msg)
+
+          | Import(alias* names)
+          | ImportFrom(identifier? module, alias* names, int? level)
+
+          | Global(identifier* names)
+          | Nonlocal(identifier* names)
+          | Expr(expr value)
+          | Pass
+          | Break
+          | Continue
+
+          -- XXX Jython will be different
+          -- col_offset is the byte offset in the utf8 string the parser uses
+          attributes (int lineno, int col_offset)
+
+          -- BoolOp() can use left & right?
+    expr = BoolOp(boolop op, expr* values)
+         | BinOp(expr left, operator op, expr right)
+         | UnaryOp(unaryop op, expr operand)
+         | Lambda(arguments args, expr body)
+         | IfExp(expr test, expr body, expr orelse)
+         | Dict(expr* keys, expr* values)
+         | Set(expr* elts)
+         | ListComp(expr elt, comprehension* generators)
+         | SetComp(expr elt, comprehension* generators)
+         | DictComp(expr key, expr value, comprehension* generators)
+         | GeneratorExp(expr elt, comprehension* generators)
+         -- the grammar constrains where yield expressions can occur
+         | Await(expr value)
+         | Yield(expr? value)
+         | YieldFrom(expr value)
+         -- need sequences for compare to distinguish between
+         -- x < 4 < 3 and (x < 4) < 3
+         | Compare(expr left, cmpop* ops, expr* comparators)
+         | Call(expr func, expr* args, keyword* keywords)
+         | Num(object n) -- a number as a PyObject.
+         | Str(string s) -- need to specify raw, unicode, etc?
+         | FormattedValue(expr value, int? conversion, expr? format_spec)
+         | JoinedStr(expr* values)
+         | Bytes(bytes s)
+         | NameConstant(singleton value)
+         | Ellipsis
+         | Constant(constant value)
+
+         -- the following expression can appear in assignment context
+         | Attribute(expr value, identifier attr, expr_context ctx)
+         | Subscript(expr value, slice slice, expr_context ctx)
+         | Starred(expr value, expr_context ctx)
+         | Name(identifier id, expr_context ctx)
+         | List(expr* elts, expr_context ctx)
+         | Tuple(expr* elts, expr_context ctx)
+
+          -- col_offset is the byte offset in the utf8 string the parser uses
+          attributes (int lineno, int col_offset)
+
+    expr_context = Load
+                 | Store
+                 | Del
+                 | AugLoad
+                 | AugStore
+                 | Param
+
+    slice = Slice(expr? lower, expr? upper, expr? step)
+          | ExtSlice(slice* dims)
+          | Index(expr value)
+
+    boolop = And
+           | Or
+
+    operator = Add
+             | Sub
+             | Mult
+             | MatMult
+             | Div
+             | Mod
+             | Pow
+             | LShift
+             | RShift
+             | BitOr
+             | BitXor
+             | BitAnd
+             | FloorDiv
+
+    unaryop = Invert
+            | Not
+            | UAdd
+            | USub
+
+    cmpop = Eq
+          | NotEq
+          | Lt
+          | LtE
+          | Gt
+          | GtE
+          | Is
+          | IsNot
+          | In
+          | NotIn
+
+    comprehension = (expr target, expr iter, expr* ifs, int is_async)
+
+    excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
+                    attributes (int lineno, int col_offset)
+
+    arguments = (arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults,
+                 arg? kwarg, expr* defaults)
+
+    arg = (identifier arg, expr? annotation)
+           attributes (int lineno, int col_offset)
+
+    -- keyword arguments supplied to call (NULL identifier for **kwargs)
+    keyword = (identifier? arg, expr value)
+
+    -- import name with optional 'as' alias.
+    alias = (identifier name, identifier? asname)
+
+    withitem = (expr context_expr, expr? optional_vars)
+}

--- a/docs/contributing/ast/python3_8.ast
+++ b/docs/contributing/ast/python3_8.ast
@@ -1,0 +1,167 @@
+-- Python 3.8 AST
+-- ASDL's 5 builtin types are:
+-- identifier, int, string, object, constant
+
+module Python version "3.8"
+{
+    mod = Module(stmt* body, type_ignore *type_ignores)
+        | Interactive(stmt* body)
+        | Expression(expr body)
+        | FunctionType(expr* argtypes, expr returns)
+
+        -- not really an actual node but useful in Jython's typesystem.
+        | Suite(stmt* body)
+
+    stmt = FunctionDef(identifier name,
+                       arguments args,
+                       stmt* body,
+                       expr* decorator_list,
+                       expr? returns,
+                       string? type_comment)
+          | AsyncFunctionDef(identifier name,
+                             arguments args,
+                             stmt* body,
+                             expr* decorator_list,
+                             expr? returns,
+                             string? type_comment)
+
+          | ClassDef(identifier name,
+                     expr* bases,
+                     keyword* keywords,
+                     stmt* body,
+                     expr* decorator_list)
+          | Return(expr? value)
+
+          | Delete(expr* targets)
+          | Assign(expr* targets, expr value, string? type_comment)
+          | AugAssign(expr target, operator op, expr value)
+          -- 'simple' indicates that we annotate simple name without parens
+          | AnnAssign(expr target, expr annotation, expr? value, int simple)
+
+          -- use 'orelse' because else is a keyword in target languages
+          | For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
+          | AsyncFor(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
+          | While(expr test, stmt* body, stmt* orelse)
+          | If(expr test, stmt* body, stmt* orelse)
+          | With(withitem* items, stmt* body, string? type_comment)
+          | AsyncWith(withitem* items, stmt* body, string? type_comment)
+
+          | Raise(expr? exc, expr? cause)
+          | Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
+          | Assert(expr test, expr? msg)
+
+          | Import(alias* names)
+          | ImportFrom(identifier? module, alias* names, int? level)
+
+          | Global(identifier* names)
+          | Nonlocal(identifier* names)
+          | Expr(expr value)
+          | Pass
+          | Break
+          | Continue
+
+          -- XXX Jython will be different
+          -- col_offset is the byte offset in the utf8 string the parser uses
+          attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
+
+          -- BoolOp() can use left & right?
+    expr = BoolOp(boolop op, expr* values)
+         | NamedExpr(expr target, expr value)
+         | BinOp(expr left, operator op, expr right)
+         | UnaryOp(unaryop op, expr operand)
+         | Lambda(arguments args, expr body)
+         | IfExp(expr test, expr body, expr orelse)
+         | Dict(expr* keys, expr* values)
+         | Set(expr* elts)
+         | ListComp(expr elt, comprehension* generators)
+         | SetComp(expr elt, comprehension* generators)
+         | DictComp(expr key, expr value, comprehension* generators)
+         | GeneratorExp(expr elt, comprehension* generators)
+         -- the grammar constrains where yield expressions can occur
+         | Await(expr value)
+         | Yield(expr? value)
+         | YieldFrom(expr value)
+         -- need sequences for compare to distinguish between
+         -- x < 4 < 3 and (x < 4) < 3
+         | Compare(expr left, cmpop* ops, expr* comparators)
+         | Call(expr func, expr* args, keyword* keywords)
+         | FormattedValue(expr value, int? conversion, expr? format_spec)
+         | JoinedStr(expr* values)
+         | Constant(constant value, string? kind)
+
+         -- the following expression can appear in assignment context
+         | Attribute(expr value, identifier attr, expr_context ctx)
+         | Subscript(expr value, slice slice, expr_context ctx)
+         | Starred(expr value, expr_context ctx)
+         | Name(identifier id, expr_context ctx)
+         | List(expr* elts, expr_context ctx)
+         | Tuple(expr* elts, expr_context ctx)
+
+          -- col_offset is the byte offset in the utf8 string the parser uses
+          attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
+
+    expr_context = Load
+                 | Store
+                 | Del
+                 | AugLoad
+                 | AugStore
+                 | Param
+
+    slice = Slice(expr? lower, expr? upper, expr? step)
+          | ExtSlice(slice* dims)
+          | Index(expr value)
+
+    boolop = And
+           | Or
+
+    operator = Add
+             | Sub
+             | Mult
+             | MatMult
+             | Div
+             | Mod
+             | Pow
+             | LShift
+             | RShift
+             | BitOr
+             | BitXor
+             | BitAnd
+             | FloorDiv
+
+    unaryop = Invert
+            | Not
+            | UAdd
+            | USub
+
+    cmpop = Eq
+          | NotEq
+          | Lt
+          | LtE
+          | Gt
+          | GtE
+          | Is
+          | IsNot
+          | In
+          | NotIn
+
+    comprehension = (expr target, expr iter, expr* ifs, int is_async)
+
+    excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
+                    attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
+
+    arguments = (arg* posonlyargs, arg* args, arg? vararg, arg* kwonlyargs,
+                 expr* kw_defaults, arg? kwarg, expr* defaults)
+
+    arg = (identifier arg, expr? annotation, string? type_comment)
+           attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
+
+    -- keyword arguments supplied to call (NULL identifier for **kwargs)
+    keyword = (identifier? arg, expr value)
+
+    -- import name with optional 'as' alias.
+    alias = (identifier name, identifier? asname)
+
+    withitem = (expr context_expr, expr? optional_vars)
+
+    type_ignore = TypeIgnore(int lineno, string tag)
+}

--- a/docs/contributing/ast/python3_8.ast
+++ b/docs/contributing/ast/python3_8.ast
@@ -18,53 +18,53 @@ module Python version "3.8"
                        expr* decorator_list,
                        expr? returns,
                        string? type_comment)
-          | AsyncFunctionDef(identifier name,
-                             arguments args,
-                             stmt* body,
-                             expr* decorator_list,
-                             expr? returns,
-                             string? type_comment)
+         | AsyncFunctionDef(identifier name,
+                            arguments args,
+                            stmt* body,
+                            expr* decorator_list,
+                            expr? returns,
+                            string? type_comment)
 
-          | ClassDef(identifier name,
-                     expr* bases,
-                     keyword* keywords,
-                     stmt* body,
-                     expr* decorator_list)
-          | Return(expr? value)
+         | ClassDef(identifier name,
+                    expr* bases,
+                    keyword* keywords,
+                    stmt* body,
+                    expr* decorator_list)
+         | Return(expr? value)
 
-          | Delete(expr* targets)
-          | Assign(expr* targets, expr value, string? type_comment)
-          | AugAssign(expr target, operator op, expr value)
-          -- 'simple' indicates that we annotate simple name without parens
-          | AnnAssign(expr target, expr annotation, expr? value, int simple)
+         | Delete(expr* targets)
+         | Assign(expr* targets, expr value, string? type_comment)
+         | AugAssign(expr target, operator op, expr value)
+         -- 'simple' indicates that we annotate simple name without parens
+         | AnnAssign(expr target, expr annotation, expr? value, int simple)
 
-          -- use 'orelse' because else is a keyword in target languages
-          | For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
-          | AsyncFor(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
-          | While(expr test, stmt* body, stmt* orelse)
-          | If(expr test, stmt* body, stmt* orelse)
-          | With(withitem* items, stmt* body, string? type_comment)
-          | AsyncWith(withitem* items, stmt* body, string? type_comment)
+         -- use 'orelse' because else is a keyword in target languages
+         | For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
+         | AsyncFor(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
+         | While(expr test, stmt* body, stmt* orelse)
+         | If(expr test, stmt* body, stmt* orelse)
+         | With(withitem* items, stmt* body, string? type_comment)
+         | AsyncWith(withitem* items, stmt* body, string? type_comment)
 
-          | Raise(expr? exc, expr? cause)
-          | Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
-          | Assert(expr test, expr? msg)
+         | Raise(expr? exc, expr? cause)
+         | Try(stmt* body, excepthandler* handlers, stmt* orelse, stmt* finalbody)
+         | Assert(expr test, expr? msg)
 
-          | Import(alias* names)
-          | ImportFrom(identifier? module, alias* names, int? level)
+         | Import(alias* names)
+         | ImportFrom(identifier? module, alias* names, int? level)
 
-          | Global(identifier* names)
-          | Nonlocal(identifier* names)
-          | Expr(expr value)
-          | Pass
-          | Break
-          | Continue
+         | Global(identifier* names)
+         | Nonlocal(identifier* names)
+         | Expr(expr value)
+         | Pass
+         | Break
+         | Continue
 
-          -- XXX Jython will be different
-          -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
+         -- XXX Jython will be different
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
 
-          -- BoolOp() can use left & right?
+         -- BoolOp() can use left & right?
     expr = BoolOp(boolop op, expr* values)
          | NamedExpr(expr target, expr value)
          | BinOp(expr left, operator op, expr right)
@@ -84,7 +84,9 @@ module Python version "3.8"
          -- need sequences for compare to distinguish between
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
-         | Call(expr func, expr* args, keyword* keywords)
+         | Call(expr func,
+                expr* args,
+                keyword* keywords)
          | FormattedValue(expr value, int? conversion, expr? format_spec)
          | JoinedStr(expr* values)
          | Constant(constant value, string? kind)
@@ -97,8 +99,8 @@ module Python version "3.8"
          | List(expr* elts, expr_context ctx)
          | Tuple(expr* elts, expr_context ctx)
 
-          -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
+         -- col_offset is the byte offset in the utf8 string the parser uses
+         attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
 
     expr_context = Load
                  | Store
@@ -149,11 +151,16 @@ module Python version "3.8"
     excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
                     attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
 
-    arguments = (arg* posonlyargs, arg* args, arg? vararg, arg* kwonlyargs,
-                 expr* kw_defaults, arg? kwarg, expr* defaults)
+    arguments = (arg* posonlyargs,
+                 arg* args,
+                 arg? vararg,
+                 arg* kwonlyargs,
+                 expr* kw_defaults,
+                 arg? kwarg,
+                 expr* defaults)
 
     arg = (identifier arg, expr? annotation, string? type_comment)
-           attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
+          attributes (int lineno, int col_offset, int? end_lineno, int? end_col_offset)
 
     -- keyword arguments supplied to call (NULL identifier for **kwargs)
     keyword = (identifier? arg, expr value)

--- a/docs/contributing/changes_from26to27.rst
+++ b/docs/contributing/changes_from26to27.rst
@@ -1,0 +1,5 @@
+Changes from Python 2.6 to Python 2.7
+-------------------------------------
+
+.. literalinclude:: ast/python2_7.ast
+   :diff: ast/python2_6.ast

--- a/docs/contributing/changes_from30to31.rst
+++ b/docs/contributing/changes_from30to31.rst
@@ -1,0 +1,5 @@
+Changes from Python 3.0 to Python 3.1
+-------------------------------------
+
+.. literalinclude:: ast/python3_1.ast
+   :diff: ast/python3_0.ast

--- a/docs/contributing/changes_from31to32.rst
+++ b/docs/contributing/changes_from31to32.rst
@@ -1,0 +1,5 @@
+Changes from Python 3.1 to Python 3.2
+-------------------------------------
+
+.. literalinclude:: ast/python3_2.ast
+   :diff: ast/python3_1.ast

--- a/docs/contributing/changes_from32to33.rst
+++ b/docs/contributing/changes_from32to33.rst
@@ -1,0 +1,5 @@
+Changes from Python 3.2 to Python 3.3
+-------------------------------------
+
+.. literalinclude:: ast/python3_3.ast
+   :diff: ast/python3_2.ast

--- a/docs/contributing/changes_from33to34.rst
+++ b/docs/contributing/changes_from33to34.rst
@@ -1,0 +1,5 @@
+Changes from Python 3.3 to Python 3.4
+-------------------------------------
+
+.. literalinclude:: ast/python3_4.ast
+   :diff: ast/python3_3.ast

--- a/docs/contributing/changes_from34to35.rst
+++ b/docs/contributing/changes_from34to35.rst
@@ -1,0 +1,5 @@
+Changes from Python 3.4 to Python 3.5
+-------------------------------------
+
+.. literalinclude:: ast/python3_5.ast
+   :diff: ast/python3_4.ast

--- a/docs/contributing/changes_from35to36.rst
+++ b/docs/contributing/changes_from35to36.rst
@@ -1,0 +1,5 @@
+Changes from Python 3.5 to Python 3.6
+-------------------------------------
+
+.. literalinclude:: ast/python3_6.ast
+   :diff: ast/python3_5.ast

--- a/docs/contributing/changes_from36to37.rst
+++ b/docs/contributing/changes_from36to37.rst
@@ -1,0 +1,5 @@
+Changes from Python 3.6 to Python 3.7
+-------------------------------------
+
+.. literalinclude:: ast/python3_7.ast
+   :diff: ast/python3_6.ast

--- a/docs/contributing/changes_from37to38.rst
+++ b/docs/contributing/changes_from37to38.rst
@@ -1,0 +1,5 @@
+Changes from Python 3.7 to Python 3.8
+-------------------------------------
+
+.. literalinclude:: ast/python3_8.ast
+   :diff: ast/python3_7.ast

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -1,9 +1,114 @@
 Contributing
 ============
 
-Contributing to RestrictedPython 4+
+Contributing to RestrictedPython
 
 Todos
 -----
 
 .. todolist::
+
+Understanding How RestrictedPython works internally
+---------------------------------------------------
+
+RestrictedPython is a classic approach of compiler construction to create a limited subset of an existing programming language.
+
+Defining a programming language requires a regular grammar (`Chomsky 3`_ / `EBNF`_) definition.
+This grammar will be implemented in an abstract syntax tree (AST), which will be passed on to a code generator to produce a machine-readable version.
+
+.. _`_sec_code_generation`:
+
+Code generation
++++++++++++++++
+
+As Python is a platform independent programming language, this machine readable version is a byte code which will be translated on the fly by an interpreter into machine code.
+This machine code then gets executed on the specific CPU architecture, with the standard operating system restrictions.
+
+The byte code produced must be compatible with the execution environment that the Python interpreter is running in, so we do not generate the byte code directly from ``compile_restricted`` and the other ``compile_restricted_*`` methods manually, it may not match what the interpreter expects.
+
+Thankfully, the Python ``compile()`` function introduced the capability to compile ``ast.AST`` code into byte code in Python 2.6, so we can return the platform-independent AST and keep byte code generation delegated to the interpreter.
+
+``ast`` module (Abstract Syntax Trees)
+++++++++++++++++++++++++++++++++++++++
+
+The ``ast`` module consists of four areas:
+
+* ``AST`` (Basis of all Nodes) + all node class implementations
+* ``NodeVisitor`` and ``NodeTransformer`` (tool to consume and modify the AST)
+* Helper methods
+
+  * ``parse``
+  * ``walk``
+  * ``dump``
+
+* Constants
+
+  * ``PyCF_ONLY_AST``
+
+
+``NodeVisitor`` & ``NodeTransformer``
++++++++++++++++++++++++++++++++++++++
+
+A ``NodeVisitor`` is a class of a node / AST consumer, it reads the data by stepping through the tree without modifying it.
+In contrast, a ``NodeTransformer`` (which inherits from a ``NodeVisitor``) is allowed to modify the tree and nodes.
+
+Modifying the AST
++++++++++++++++++
+
+
+Technical Backgrounds - Links to External Documentation
++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+* Concept of Immutable Types and Python Example (https://en.wikipedia.org/wiki/Immutable_object#Python)
+* Python 3 Standard Library Documentation on AST module ``ast`` (https://docs.python.org/3/library/ast.html)
+
+  * AST Grammar of Python
+
+    * `Python 3.8 AST`_
+    * `Python 3.7 AST`_
+    * `Python 3.6 AST`_
+    * `Python 3.5 AST`_
+    * `Python 3.4 AST`_ (obsolete)
+    * `Python 3.3 AST`_ (obsolete)
+    * `Python 3.2 AST`_ (obsolete)
+    * `Python 3.1 AST`_ (obsolete)
+    * `Python 3.0 AST`_ (obsolete)
+    * `Python 2.7 AST`_
+    * `Python 2.6 AST`_ (obsolete)
+
+  * ``NodeVistiors``  (https://docs.python.org/3.5/library/ast.html#ast.NodeVisitor)
+  * ``NodeTransformer``  (https://docs.python.org/3.5/library/ast.html#ast.NodeTransformer)
+  * ``dump`` (https://docs.python.org/3.5/library/ast.html#ast.dump)
+
+* In detail Documentation on the Python AST module ``ast`` (Green Tree Snakes) (https://greentreesnakes.readthedocs.org/en/latest/)
+* Example how to Instrumenting the Python AST (``ast.AST``) (http://www.dalkescientific.com/writings/diary/archive/2010/02/22/instrumenting_the_ast.html)
+
+.. _`CamelCase`: https://en.wikipedia.org/wiki/Camel_case
+
+.. _`EBNF`: https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form
+
+.. _`Chomsky 3`: https://en.wikipedia.org/wiki/Chomsky_hierarchy#Type-3_grammars
+
+.. _`Python 3.8 AST`: https://docs.python.org/3.7/library/ast.html#abstract-grammar
+
+.. _`Python 3.7 AST`: https://docs.python.org/3.7/library/ast.html#abstract-grammar
+
+.. _`Python 3.6 AST`: https://docs.python.org/3.6/library/ast.html#abstract-grammar
+
+.. _`Python 3.5 AST`: https://docs.python.org/3.5/library/ast.html#abstract-grammar
+
+.. _`Python 3.4 AST`: https://docs.python.org/3.4/library/ast.html#abstract-grammar
+
+.. _`Python 3.3 AST`: https://docs.python.org/3.3/library/ast.html#abstract-grammar
+
+.. _`Python 3.2 AST`: https://docs.python.org/3.2/library/ast.html#abstract-grammar
+
+.. _`Python 3.1 AST`: https://docs.python.org/3.1/library/ast.html#abstract-grammar
+
+.. _`Python 3.0 AST`: https://docs.python.org/3.0/library/ast.html#abstract-grammar
+
+.. _`Python 2.7 AST`: https://docs.python.org/2.7/library/ast.html#abstract-grammar
+
+.. _`Python 2.6 AST`: https://docs.python.org/2.6/library/ast.html#abstract-grammar
+
+A (modified style) Copy of all Abstract Grammar Definitions for the Python versions does live in this Documentation (ast Subfolder) to help finding difference quicker by comparing files.

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -52,15 +52,12 @@ The ``ast`` module consists of four areas:
 A ``NodeVisitor`` is a class of a node / AST consumer, it reads the data by stepping through the tree without modifying it.
 In contrast, a ``NodeTransformer`` (which inherits from a ``NodeVisitor``) is allowed to modify the tree and nodes.
 
-Modifying the AST
-+++++++++++++++++
-
 
 Technical Backgrounds - Links to External Documentation
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-* Concept of Immutable Types and Python Example (https://en.wikipedia.org/wiki/Immutable_object#Python)
-* Python 3 Standard Library Documentation on AST module ``ast`` (https://docs.python.org/3/library/ast.html)
+* `Concept of Immutable Types and Python Example`_
+* `Python 3 Standard Library Documentation on AST module`_
 
   * AST Grammar of Python
 
@@ -76,12 +73,37 @@ Technical Backgrounds - Links to External Documentation
     * `Python 2.7 AST`_
     * `Python 2.6 AST`_ (obsolete)
 
-  * ``NodeVistiors``  (https://docs.python.org/3.5/library/ast.html#ast.NodeVisitor)
-  * ``NodeTransformer``  (https://docs.python.org/3.5/library/ast.html#ast.NodeTransformer)
-  * ``dump`` (https://docs.python.org/3.5/library/ast.html#ast.dump)
+  * `AST NodeVistiors Class`_  (https://docs.python.org/3.5/library/ast.html#ast.NodeVisitor)
+  * `AST NodeTransformer Class`_  (https://docs.python.org/3.5/library/ast.html#ast.NodeTransformer)
+  * `AST dump method`_ (https://docs.python.org/3.5/library/ast.html#ast.dump)
 
-* In detail Documentation on the Python AST module ``ast`` (Green Tree Snakes) (https://greentreesnakes.readthedocs.org/en/latest/)
-* Example how to Instrumenting the Python AST (``ast.AST``) (http://www.dalkescientific.com/writings/diary/archive/2010/02/22/instrumenting_the_ast.html)
+* `In detail Documentation on the Python AST module (Green Tree Snakes)`_
+* `Example how to Instrumenting the Python AST`_
+
+Differences between different Python versions
+---------------------------------------------
+
+A (modified style) Copy of all Abstract Grammar Definitions for the Python versions does live in this Documentation (ast Subfolder) to help finding difference quicker by comparing files.
+
+.. toctree::
+   :maxdepth: 2
+
+   changes_from26to27
+   changes_from30to31
+   changes_from31to32
+   changes_from32to33
+   changes_from33to34
+   changes_from34to35
+   changes_from35to36
+   changes_from36to37
+   changes_from37to38
+
+
+.. Links
+
+.. _`Concept of Immutable Types and Python Example`: https://en.wikipedia.org/wiki/Immutable_object#Python
+
+.. _`Python 3 Standard Library Documentation on AST module`: https://docs.python.org/3/library/ast.html
 
 .. _`CamelCase`: https://en.wikipedia.org/wiki/Camel_case
 
@@ -89,7 +111,7 @@ Technical Backgrounds - Links to External Documentation
 
 .. _`Chomsky 3`: https://en.wikipedia.org/wiki/Chomsky_hierarchy#Type-3_grammars
 
-.. _`Python 3.8 AST`: https://docs.python.org/3.7/library/ast.html#abstract-grammar
+.. _`Python 3.8 AST`: https://docs.python.org/3.8/library/ast.html#abstract-grammar
 
 .. _`Python 3.7 AST`: https://docs.python.org/3.7/library/ast.html#abstract-grammar
 
@@ -111,4 +133,13 @@ Technical Backgrounds - Links to External Documentation
 
 .. _`Python 2.6 AST`: https://docs.python.org/2.6/library/ast.html#abstract-grammar
 
-A (modified style) Copy of all Abstract Grammar Definitions for the Python versions does live in this Documentation (ast Subfolder) to help finding difference quicker by comparing files.
+
+.. _`AST NodeVistiors Class`: https://docs.python.org/3.5/library/ast.html#ast.NodeVisitor
+
+.. _`AST NodeTransformer Class`: https://docs.python.org/3.5/library/ast.html#ast.NodeTransformer
+
+.. _`AST dump method`: https://docs.python.org/3.5/library/ast.html#ast.dump
+
+.. _`In detail Documentation on the Python AST module (Green Tree Snakes)`: https://greentreesnakes.readthedocs.org/en/latest/
+
+.. _`Example how to Instrumenting the Python AST`: http://www.dalkescientific.com/writings/diary/archive/2010/02/22/instrumenting_the_ast.html


### PR DESCRIPTION
Some of the documentation got removed, when cutting the 4.0 release.

I readd some of the documentation as a remainder how RestrictedPython works internally and the AST Grammar files as they help to understand changes between Python Versions that may affects RestrictedPython. 