### PR TITLE
Require Python 2 compatible pytest-html version.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     datetime: DateTime
     -cconstraints.txt
     pytest-cov
-    pytest-html
+    pytest-html < 2
 
 [testenv:coverage]
 basepython = python2.7


### PR DESCRIPTION
This should fix the AppVeyor tests.
TravisCI does not seem to show these problem because it caches the old version.