### PR TITLE
Fix ``compile_restricted_function`` with SyntaxErrors that have no text

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 5.1a0 (unreleased)
 ------------------
 
+- Fix ``compile_restricted_function`` with SyntaxErrors that have no text
+  (`#181 <https://github.com/zopefoundation/RestrictedPython/issues/181>`_)
+
 - Drop install dependency on ``setuptools``.
   (`#189 <https://github.com/zopefoundation/RestrictedPython/issues/189>`_)
 

--- a/src/RestrictedPython/compile.py
+++ b/src/RestrictedPython/compile.py
@@ -150,7 +150,7 @@ def compile_restricted_function(
             lineno=v.lineno,
             type=v.__class__.__name__,
             msg=v.msg,
-            statement=v.text.strip())
+            statement=v.text.strip() if v.text else None)
         return CompileResult(
             code=None, errors=(error,), warnings=(), used_names=())
 

--- a/tests/test_compile_restricted_function.py
+++ b/tests/test_compile_restricted_function.py
@@ -1,6 +1,7 @@
 from RestrictedPython import compile_restricted_function
 from RestrictedPython import PrintCollector
 from RestrictedPython import safe_builtins
+from RestrictedPython._compat import IS_PY38_OR_GREATER
 from types import FunctionType
 
 
@@ -212,3 +213,28 @@ def test_compile_restricted_function_handle_SyntaxError():
     assert result.errors == (
         "Line 1: SyntaxError: unexpected EOF while parsing at statement: 'a('",
     )
+
+
+def test_compile_restricted_function_invalid_syntax():
+    p = ''
+    body = '1=1'
+    name = 'broken'
+
+    result = compile_restricted_function(
+        p,  # parameters
+        body,
+        name,
+    )
+
+    assert result.code is None
+    assert len(result.errors) == 1
+    error_msg = result.errors[0]
+
+    if IS_PY38_OR_GREATER:
+        assert error_msg.startswith(
+            "Line 1: SyntaxError: cannot assign to literal at statement:"
+        )
+    else:
+        assert error_msg.startswith(
+            "Line 1: SyntaxError: can't assign to literal at statement:"
+        )


### PR DESCRIPTION
Fixes #181 - fashioned after #137 