### PR TITLE
Avoid deprecation warnings when using Python 3.8+.

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "3ffdf08eda5163647c93d7e25faca354d176ae77"
+commit-id = "886173bf647a6e80a985544c32053c932b1949e2"
 
 [python]
 with-pypy = false
@@ -51,7 +51,7 @@ testenv-additional = [
     "    coverage combine",
     "    coverage html",
     "    coverage report -m --fail-under=100",
-    "depends = py27,py35,py36,py39-datetime,py37,py38,py39,coverage",
+    "depends = py27,py35,py36,py37,py38,py39,py39-datetime,py310,coverage",
     ]
 coverage-basepython = "python3.8"
 coverage-command = "pytest --cov=src --cov=tests --cov-report= {posargs}"
@@ -60,7 +60,7 @@ coverage-setenv = [
     ]
 
 [coverage]
-fail-under = 98.9
+fail-under = 98.7
 
 [manifest]
 additional-rules = [

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changes
 
 - Document that ``__name__`` is needed to define classes.
 
+- Avoid deprecation warnings when using Python 3.8+.
+  (`#192 <https://github.com/zopefoundation/RestrictedPython/issues/192>`_)
+
 - Allow to use the package with Python 3.10 -- Caution: No security audit has
   been done so far.
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -5,3 +5,6 @@ isort >= 4.3.2
 # Needed for Appveyor as long as PY2 is supported:
 pytest < 5
 pytest-html < 2
+# coverage 6+ no longer supports Python 2 and coverage results of older
+# versions cannot not combined with newer ones:
+coverage < 6

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ commands =
     coverage combine
     coverage html
     coverage report -m --fail-under=100
-depends = py27,py35,py36,py39-datetime,py37,py38,py39,coverage
+depends = py27,py35,py36,py37,py38,py39,py39-datetime,py310,coverage
 
 [testenv:lint]
 basepython = python3
@@ -92,7 +92,7 @@ commands =
     pytest --cov=src --cov=tests --cov-report= {posargs}
     coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
     coverage html
-    coverage report -m --fail-under=98.9
+    coverage report -m --fail-under=98.7
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
Fixes #192.