### PR TITLE
Fix ast deprecations for 3.12

### DIFF
--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -28,7 +28,7 @@ from ._compat import IS_PY38_OR_GREATER
 if IS_PY38_OR_GREATER:
     astStr = ast.Constant
     astNum = ast.Constant
-else:
+else:  # pragma: no cover
     astStr = ast.Str
     astNum = ast.Num
 
@@ -127,14 +127,14 @@ def copy_locations(new_node, old_node):
     assert 'lineno' in new_node._attributes
     new_node.lineno = old_node.lineno
 
-    if IS_PY38_OR_GREATER:
+    if IS_PY38_OR_GREATER:  # pragma: no branch
         assert 'end_lineno' in new_node._attributes
         new_node.end_lineno = old_node.end_lineno
 
     assert 'col_offset' in new_node._attributes
     new_node.col_offset = old_node.col_offset
 
-    if IS_PY38_OR_GREATER:
+    if IS_PY38_OR_GREATER:  # pragma: no branch
         assert 'end_col_offset' in new_node._attributes
         new_node.end_col_offset = old_node.end_col_offset
 
@@ -492,7 +492,7 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
             if isinstance(node, ast.Module):
                 _print.lineno = position
                 _print.col_offset = position
-                if IS_PY38_OR_GREATER:
+                if IS_PY38_OR_GREATER:  # pragma: no branch
                     _print.end_lineno = position
                     _print.end_col_offset = position
                 ast.fix_missing_locations(_print)
@@ -554,7 +554,7 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
                 return
             return self.node_contents_visit(node)
 
-    else:
+    else:  # pragma: no cover
 
         def visit_Num(self, node):
             """Allow integer numbers without restrictions.

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -25,6 +25,14 @@ import textwrap
 from ._compat import IS_PY38_OR_GREATER
 
 
+if IS_PY38_OR_GREATER:
+    astStr = ast.Constant
+    astNum = ast.Constant
+else:
+    astStr = ast.Str
+    astNum = ast.Num
+
+
 # For AugAssign the operator must be converted to a string.
 IOPERATOR_TO_STR = {
     ast.Add: '+=',
@@ -272,7 +280,7 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         """
         spec = ast.Dict(keys=[], values=[])
 
-        spec.keys.append(ast.Str('childs'))
+        spec.keys.append(astStr('childs'))
         spec.values.append(ast.Tuple([], ast.Load()))
 
         # starred elements in a sequence do not contribute into the min_len.
@@ -292,12 +300,12 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
 
             elif isinstance(val, ast.Tuple):
                 el = ast.Tuple([], ast.Load())
-                el.elts.append(ast.Num(idx - offset))
+                el.elts.append(astNum(idx - offset))
                 el.elts.append(self.gen_unpack_spec(val))
                 spec.values[0].elts.append(el)
 
-        spec.keys.append(ast.Str('min_len'))
-        spec.values.append(ast.Num(min_len))
+        spec.keys.append(astStr('min_len'))
+        spec.values.append(astNum(min_len))
 
         return spec
 
@@ -903,7 +911,7 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
             node = self.node_contents_visit(node)
             new_node = ast.Call(
                 func=ast.Name('_getattr_', ast.Load()),
-                args=[node.value, ast.Str(node.attr)],
+                args=[node.value, astStr(node.attr)],
                 keywords=[])
 
             copy_locations(new_node, node)
@@ -1107,7 +1115,7 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
                 value=ast.Call(
                     func=ast.Name('_inplacevar_', ast.Load()),
                     args=[
-                        ast.Str(IOPERATOR_TO_STR[type(node.op)]),
+                        astStr(IOPERATOR_TO_STR[type(node.op)]),
                         ast.Name(node.target.id, ast.Load()),
                         node.value
                     ],

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -45,7 +45,7 @@ def test_compile__invalid_syntax():
         assert "SyntaxError: cannot assign to literal here." in str(err.value)
     elif IS_PY38_OR_GREATER:
         assert "cannot assign to literal at statement:" in str(err.value)
-    else:
+    else:  # pragma: no cover
         assert "can't assign to literal at statement:" in str(err.value)
 
 

--- a/tests/test_compile_restricted_function.py
+++ b/tests/test_compile_restricted_function.py
@@ -36,7 +36,7 @@ return printed
     safe_locals = {}
     exec(result.code, safe_globals, safe_locals)
     hello_world = safe_locals['hello_world']
-    assert type(hello_world) == FunctionType
+    assert isinstance(hello_world, FunctionType)
     assert hello_world() == 'Hello World!\n'
 
 
@@ -102,7 +102,7 @@ return printed
     safe_locals = {}
     exec(result.code, safe_globals, safe_locals)
     hello_world = safe_locals['hello_world']
-    assert type(hello_world) == FunctionType
+    assert isinstance(hello_world, FunctionType)
     assert hello_world('Hello ', 'World!') == 'Hello World!\n'
 
 
@@ -136,7 +136,7 @@ return printed
     safe_locals = {}
     exec(result.code, safe_globals, safe_locals)
     hello_world = safe_locals['hello_world']
-    assert type(hello_world) == FunctionType
+    assert isinstance(hello_world, FunctionType)
     assert hello_world() == 'Hello World!\n'
 
 
@@ -165,7 +165,7 @@ def test_compile_restricted_function_pretends_the_code_is_executed_in_a_global_s
     safe_locals = {}
     exec(result.code, safe_globals, safe_locals)
     hello_world = safe_locals['hello_world']
-    assert type(hello_world) == FunctionType
+    assert isinstance(hello_world, FunctionType)
     hello_world()
     assert safe_globals['output'] == 'foobar'
 
@@ -195,7 +195,7 @@ def test_compile_restricted_function_allows_invalid_python_identifiers_as_functi
     safe_locals = {}
     exec(result.code, safe_globals, safe_locals)
     generated_function = tuple(safe_locals.values())[0]
-    assert type(generated_function) == FunctionType
+    assert isinstance(generated_function, FunctionType)
     generated_function()
     assert safe_globals['output'] == 'foobar'
 

--- a/tests/test_compile_restricted_function.py
+++ b/tests/test_compile_restricted_function.py
@@ -246,7 +246,7 @@ def test_compile_restricted_function_invalid_syntax():
         assert error_msg.startswith(
             "Line 1: SyntaxError: cannot assign to literal at statement:"
         )
-    else:
+    else:  # pragma: no cover
         assert error_msg.startswith(
             "Line 1: SyntaxError: can't assign to literal at statement:"
         )

--- a/tests/transformer/test_dict_comprehension.py
+++ b/tests/transformer/test_dict_comprehension.py
@@ -36,7 +36,7 @@ def test_dict_comprehension_with_attrs(mocker):
             mocker.call(z[1], 'k'),
             mocker.call(z[1], 'v'),
         ])
-    else:
+    else:  # praga: no cover
         calls.extend([
             mocker.call(z[0], 'k'),
             mocker.call(z[1], 'k'),


### PR DESCRIPTION
`ast.Str` and `ast.Num` have been deprecated since Python 3.8. Starting with `3.12`, they will now emit DeprecationWarnings. Replace them with calls to `ast.Constant` for Python 3.8+.

An alternative would be to drop support for Python 3.7.

```
DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
DeprecationWarning: ast.Num is deprecated and will be removed in Python 3.14; use ast.Constant instead
```

https://docs.python.org/3.12/library/ast.html#ast.AST