### PR TITLE
allow `@` expressions

### DIFF
--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -61,6 +61,7 @@ ALLOWED_FUNC_NAMES = frozenset([
     '__ne__',
     '__gt__',
     '__ge__',
+    '__matmult__'
 ])
 
 

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -768,8 +768,8 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         return self.node_contents_visit(node)
 
     def visit_MatMult(self, node):
-        """Matrix multiplication (`@`) is currently not allowed."""
-        self.not_allowed(node)
+        """Allow `@` expressions."""
+        return self.node_contents_visit(node)
 
     def visit_BoolOp(self, node):
         """Allow bool operator without restrictions."""

--- a/tests/transformer/operators/test_arithmetic_operators.py
+++ b/tests/transformer/operators/test_arithmetic_operators.py
@@ -33,8 +33,16 @@ def test_FloorDiv():
 
 
 def test_MatMult():
-    result = compile_restricted_eval('(8, 3, 5) @ (2, 7, 1)')
-    assert result.errors == (
-        'Line None: MatMult statements are not allowed.',
-    )
-    assert result.code is None
+    source_code = """
+class Vector:
+    def __init__(self, values):
+        self.values = values
+
+    def __matmul__(self, other):
+        return sum(x * y for x, y in zip(self.values, other.values))
+
+result = Vector((8, 3, 5)) @ Vector((2, 7, 1))
+"""
+    # Assuming restricted_eval can execute the source_code and return the value of 'result'
+    assert restricted_eval(source_code) == 42
+    

--- a/tests/transformer/operators/test_arithmetic_operators.py
+++ b/tests/transformer/operators/test_arithmetic_operators.py
@@ -32,8 +32,7 @@ def test_FloorDiv():
     assert restricted_eval('7 // 2') == 3
 
 
-def test_MatMult():
-    source_code = """
+test_matmult = """\
 class Vector:
     def __init__(self, values):
         self.values = values
@@ -43,6 +42,7 @@ class Vector:
 
 result = Vector((8, 3, 5)) @ Vector((2, 7, 1))
 """
-    # Assuming restricted_eval can execute the source_code and return the value of 'result'
-    assert restricted_eval(source_code) == 42
+
+def test_MatMult():
+    assert restricted_eval(test_matmult) == 42
     


### PR DESCRIPTION
this commit updates transformers.py to allow `@` expressions. would close https://github.com/zopefoundation/RestrictedPython/issues/268.
