### PR TITLE
Update docs (upgrade the maximum supported python version to 3.14)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ RestrictedPython is not a sandbox system or a secured environment, but it helps 
 Supported Python versions
 =========================
 
-RestrictedPython supports CPython 3.9 up to 3.13.
+RestrictedPython supports CPython 3.9 up to 3.14.
 It does _not_ support PyPy or other alternative Python implementations.
 
 Contents


### PR DESCRIPTION
Starting from version 8.1, RestrictedPython supports python 3.14, but the documentation states that only versions up to 3.13 are supported.

- [ ] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization. (I think it's a trivial typo fixes.)
- [x] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html). (I can't create branches, so I use a fork. All other recommendations have been followed.)
- [ ] I successfully ran code quality checks on my changes locally. (not applicable)
- [ ] I successfully ran tests on my changes locally. (not applicable)
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [ ] I included a change log entry in my commits. (not required)

