### PR TITLE
Fix support python 3.14

### DIFF
--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -356,7 +356,7 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
         return (tmp_target, cleanup)
 
     def gen_none_node(self):
-        return ast.NameConstant(value=None)
+        return ast.Constant(None)
 
     def gen_del_stmt(self, name_to_del):
         return ast.Delete(targets=[ast.Name(name_to_del, ast.Del())])

--- a/tests/transformer/test_gen.py
+++ b/tests/transformer/test_gen.py
@@ -1,0 +1,9 @@
+import ast
+
+from RestrictedPython.transformer import RestrictingNodeTransformer
+
+
+def test_RestrictingNodeTransformer__gen_none_node__1():
+    node = RestrictingNodeTransformer().gen_none_node()
+    assert node.value is None
+    assert isinstance(node, ast.Constant)


### PR DESCRIPTION
- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html). (I can't create branches, so I use a fork. All other recommendations have been followed.)
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [ ] I included a change log entry in my commits.

-----

`RestrictingNodeTransformer.gen_none_node` is not used in RestructedPython, I left the method for backward compatibility, because it can be used by other packages.
