### PR TITLE
Check positional-only argument names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changes
 8.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Also validate positional-only argument names (parameters before ``/``) so
+  they cannot start with an underscore, closing a sandbox escape where a
+  positional-only parameter could shadow an injected protected name such as
+  ``_getattr_``, ``_getitem_``, ``_write_`` or ``_print_``.
 
 
 8.3a1.dev0 (2026-05-29)

--- a/src/RestrictedPython/transformer.py
+++ b/src/RestrictedPython/transformer.py
@@ -387,6 +387,9 @@ class RestrictingNodeTransformer(ast.NodeTransformer):
             self.error(node, f'"{name}" is a reserved name.')
 
     def check_function_argument_names(self, node):
+        for arg in node.args.posonlyargs:
+            self.check_name(node, arg.arg)
+
         for arg in node.args.args:
             self.check_name(node, arg.arg)
 


### PR DESCRIPTION
Argument name validation skips positional-only parameters.

`check_function_argument_names` checks regular args, `*args`, `**kwargs`, and keyword-only args for forbidden underscore names, but not positional-only ones (before `/`).