### PR TITLE
Configuring for pure-python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,8 +47,8 @@ jobs:
       with:
         persist-credentials: false
     - name: Install uv + caching
-      # astral/setup-uv@9.0.0
-      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+      # astral/setup-uv@10.0.0
+      uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d
       with:
         enable-cache: true
         cache-dependency-glob: |

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [meta]
 template = "pure-python"
-commit-id = "3d9788fb"
+commit-id = "f40a2b2b"
 
 [python]
 with-pypy = false
@@ -40,6 +40,15 @@ additional-sources = "{toxinidir}/tests"
 
 [flake8]
 additional-sources = "tests"
+
+[pre-commit]
+additional-config = [
+    "- repo: https://github.com/pre-commit/mirrors-mypy",
+    "  rev: v2.1.0",
+    "  hooks:",
+    "    - id: mypy",
+    "      pass_filenames: false",
+    ]
 
 [manifest]
 additional-rules = [


### PR DESCRIPTION
Adds `[pre-commit] additional-config` so the mypy hook survives regeneration. Depends on zopefoundation/meta#446.

No change in `.pre-commit-config.yaml` because the change is identical to what we already have there.